### PR TITLE
Make ScopeBuilder variables protected

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3')
+        classpath('io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0')
     }
 }
 
@@ -33,7 +33,6 @@ plugins {
     id 'signing'
     id 'checkstyle'
     id 'jacoco'
-    id 'net.researchgate.release' version '2.6.0' apply false
     id 'com.github.kt3k.coveralls' version '2.8.1'
 }
 
@@ -46,13 +45,12 @@ configurations.archives.artifacts.clear()
 
 allprojects {
     group = 'com.uber.m3'
-    version = '0.0.1-SNAPSHOT'
+    version = '0.1.1'
 
     apply plugin: 'java'
     apply plugin: 'maven'
     apply plugin: 'signing'
     apply plugin: 'jacoco'
-    apply plugin: 'net.researchgate.release'
 
     sourceCompatibility = 1.7
     targetCompatibility = 1.7
@@ -125,12 +123,6 @@ allprojects {
             }
         }
     }
-
-    release {
-        tagTemplate = '$name-$version'
-    }
-
-    afterReleaseBuild.dependsOn uploadArchives
 }
 
 subprojects {

--- a/core/src/main/java/com/uber/m3/tally/ScopeBuilder.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeBuilder.java
@@ -50,11 +50,11 @@ public class ScopeBuilder {
         Duration.ofSeconds(5),
     });
 
-    StatsReporter reporter = null;
-    String prefix = "";
-    String separator = DEFAULT_SEPARATOR;
-    ImmutableMap<String, String> tags;
-    Buckets defaultBuckets = DEFAULT_SCOPE_BUCKETS;
+    protected StatsReporter reporter = null;
+    protected String prefix = "";
+    protected String separator = DEFAULT_SEPARATOR;
+    protected ImmutableMap<String, String> tags;
+    protected Buckets defaultBuckets = DEFAULT_SCOPE_BUCKETS;
 
     private ScheduledExecutorService scheduler;
     private ScopeImpl.Registry registry;
@@ -140,13 +140,14 @@ public class ScopeBuilder {
      * @return the root scope created
      */
     public Scope reportEvery(Duration interval) {
-        ScopeImpl scope = build();
+        if (interval.compareTo(Duration.ZERO) <= 0) {
+            throw new IllegalArgumentException("Reporting interval must be a positive Duration");
+        }
 
+        ScopeImpl scope = build();
         registry.subscopes.put(ScopeImpl.keyForPrefixedStringMap(prefix, tags), scope);
 
-        if (interval.compareTo(Duration.ZERO) > 0) {
-            scheduler.scheduleWithFixedDelay(scope.new ReportLoop(), 0, interval.toMillis(), TimeUnit.MILLISECONDS);
-        }
+        scheduler.scheduleWithFixedDelay(scope.new ReportLoop(), 0, interval.toMillis(), TimeUnit.MILLISECONDS);
 
         return scope;
     }

--- a/core/src/test/java/com/uber/m3/tally/ScopeImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/ScopeImplTest.java
@@ -229,4 +229,9 @@ public class ScopeImplTest {
         assertEquals("snapshot-timer", timers.get("snapshot-timer+").name());
         assertEquals(null, timers.get("snapshot-timer+").tags());
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nonPositiveReportInterval() {
+        new RootScopeBuilder().reportEvery(Duration.ofSeconds(-10));
+    }
 }

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -564,21 +564,22 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
      * Builder pattern to construct an {@link M3Reporter}.
      */
     public static class Builder {
-        private SocketAddress[] socketAddresses;
-        private String service;
-        private String env;
-        private ExecutorService executor = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
+        protected SocketAddress[] socketAddresses;
+        protected String service;
+        protected String env;
+        protected ExecutorService executor = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
         // Non-generic EMPTY ImmutableMap will never contain any elements
         @SuppressWarnings("unchecked")
-        private ImmutableMap<String, String> commonTags = ImmutableMap.EMPTY;
+        protected ImmutableMap<String, String> commonTags = ImmutableMap.EMPTY;
+        protected boolean includeHost = true;
+        protected int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
+        protected int maxPacketSizeBytes = DEFAULT_MAX_PACKET_SIZE;
+        protected int maxProcessorWaitUntilFlushMillis = 10_000;
+        protected String histogramBucketIdName = DEFAULT_HISTOGRAM_BUCKET_ID_NAME;
+        protected String histogramBucketName = DEFAULT_HISTOGRAM_BUCKET_NAME;
+        protected int histogramBucketTagPrecision = DEFAULT_HISTOGRAM_BUCKET_TAG_PRECISION;
+
         private Set<MetricTag> metricTagSet;
-        private boolean includeHost = true;
-        private int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
-        private int maxPacketSizeBytes = DEFAULT_MAX_PACKET_SIZE;
-        private int maxProcessorWaitUntilFlushMillis = 10_000;
-        private String histogramBucketIdName = DEFAULT_HISTOGRAM_BUCKET_ID_NAME;
-        private String histogramBucketName = DEFAULT_HISTOGRAM_BUCKET_NAME;
-        private int histogramBucketTagPrecision = DEFAULT_HISTOGRAM_BUCKET_TAG_PRECISION;
 
         /**
          * Constructs a {@link Builder}. Having at least one {@code SocketAddress} is required.


### PR DESCRIPTION
Making `ScopeBuilder` internal variables protected.

We don't need the `net.researchgate.release` plugin and associated attributes because our release process is to deploy to Maven Central instead of via tags.