### PR TITLE
Expose M3 utility test classes

### DIFF
--- a/m3/build.gradle
+++ b/m3/build.gradle
@@ -43,6 +43,20 @@ compileThrift {
     }
 }
 
+task testJar(type: Jar) {
+    classifier = 'test'
+
+    from (sourceSets.test.output) {
+        // Test classes will probably not be useful to others
+        exclude '**/*Test*'
+    }
+}
+
+// Expose testing utility classes
+artifacts {
+    archives testJar
+}
+
 jmh {
     benchmarkMode = ['Throughput']
 


### PR DESCRIPTION
Expose `MockM3Server` and `MockM3Service` classes to allow clients to more easily write tests against an M3Reporter.