### PR TITLE
Make Stopwatch.Stop() lowercase.

### DIFF
--- a/core/src/main/java/com/uber/m3/tally/Stopwatch.java
+++ b/core/src/main/java/com/uber/m3/tally/Stopwatch.java
@@ -44,7 +44,16 @@ public class Stopwatch {
     /**
      * Stop the stopwatch.
      */
-    public void Stop() {
+    public void stop() {
         recorder.recordStopwatch(startNanos);
+    }
+
+    /**
+     * Stop the stopwatch.
+     * @deprecated because the wrong casing was used. Use {@link #stop()} instead.
+     */
+    @Deprecated
+    public void Stop() {
+        stop();
     }
 }

--- a/core/src/test/java/com/uber/m3/tally/TimerImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/TimerImplTest.java
@@ -48,7 +48,7 @@ public class TimerImplTest {
         assertEquals(Duration.ofMinutes(2), reporter.nextTimerVal());
 
         Stopwatch stopwatch = timer.start();
-        stopwatch.Stop();
+        stopwatch.stop();
 
         Duration duration = reporter.nextTimerVal();
         assertNotNull(duration);


### PR DESCRIPTION
Normally methods are lowercase in Java. I added a lowercase version of `stop` and marked the uppercase one as deprecated. This makes sure we don't break backwards compatibility.