### PR TITLE
copy tags before modifing in M3Reporter

### DIFF
--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -423,6 +423,10 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
             // We know that the HashMap will only contain two items at this point,
             // therefore initialCapacity of 2 and loadFactor of 1.
             tags = new HashMap<>(2, 1);
+        } else {
+            // Copy over the map since it might be unmodifiable and, even if it's
+            // not, we don't want to modify it.
+            tags = new HashMap<>(tags);
         }
 
         for (int i = 0; i < bucketPairs.length; i++) {


### PR DESCRIPTION
There's an (unhandled) exception when reporting histograms using the M3Reporter:

```
java.lang.UnsupportedOperationException
	at com.uber.m3.util.ImmutableMap.put(ImmutableMap.java:129)
	at com.uber.m3.tally.m3.M3Reporter.reportHistogramDurationSamples(M3Reporter.java:434)
	at com.uber.m3.tally.HistogramImpl.report(HistogramImpl.java:136)
	at com.uber.m3.tally.ScopeImpl.report(ScopeImpl.java:196)
	at com.uber.m3.tally.ScopeImpl.reportLoopIteration(ScopeImpl.java:360)
	at com.uber.m3.tally.ScopeImpl.access$000(ScopeImpl.java:35)
	at com.uber.m3.tally.ScopeImpl$ReportLoop.run(ScopeImpl.java:369)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset$$$capture(FutureTask.java:308)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

This is caused by the tags being modified by the M3Reporter and the tag-map being a UnmodifiableMap. 