### PR TITLE
Fix NullPointerException in ScopeImpl.close

### DIFF
--- a/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
@@ -172,8 +172,10 @@ class ScopeImpl implements Scope {
         // all metrics.
         reportLoopIteration();
 
-        // Now that all metrics should be known to the reporter, close the reporter
-        reporter.close();
+        if (reporter != null) {
+            // Now that all metrics should be known to the reporter, close the reporter
+            reporter.close();
+        }
     }
 
     /**

--- a/core/src/test/java/com/uber/m3/tally/ScopeImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/ScopeImplTest.java
@@ -22,6 +22,8 @@ package com.uber.m3.tally;
 
 import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
+
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -107,6 +109,16 @@ public class ScopeImplTest {
 
         // Make sure the reporter received gauge update
         assertEquals(123, reporter.nextGaugeVal(), EPSILON);
+    }
+
+    @Test
+    public void closeWithoutReporter() throws ScopeCloseException {
+        try (Scope scope = new RootScopeBuilder().reportEvery(Duration.ofMinutes(1))) {
+            // Create a gauge, update it, and let the AutoCloseable interface
+            // functionality close the scope right away.
+            Gauge shortLifeGauge = scope.gauge("shortLifeGauge");
+            shortLifeGauge.update(123);
+        }
     }
 
     @Test

--- a/core/src/test/java/com/uber/m3/tally/ScopeImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/ScopeImplTest.java
@@ -23,7 +23,6 @@ package com.uber.m3.tally;
 import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.HashMap;


### PR DESCRIPTION
Reporter is not required and everywhere where it's being used, it's surrounded with a null check; except in `ScopeImpl.close`...