### PR TITLE
remove global lock for subscope computation

### DIFF
--- a/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
@@ -331,26 +331,16 @@ class ScopeImpl implements Scope {
 
         String key = keyForPrefixedStringMap(prefix, mergedTags);
 
-        Scope subscope;
-
-        synchronized (registry.allocationLock) {
-            if (!registry.subscopes.containsKey(key)) {
-                registry.subscopes.put(
-                    key,
-                    new ScopeBuilder(scheduler, registry)
-                        .reporter(reporter)
-                        .prefix(prefix)
-                        .separator(separator)
-                        .tags(mergedTags)
-                        .defaultBuckets(defaultBuckets)
-                        .build()
-                );
-            }
-
-            subscope = registry.subscopes.get(key);
-        }
-
-        return subscope;
+        return registry.subscopes.computeIfAbsent(
+            key,
+            (k) -> new ScopeBuilder(scheduler, registry)
+                .reporter(reporter)
+                .prefix(prefix)
+                .separator(separator)
+                .tags(mergedTags)
+                .defaultBuckets(defaultBuckets)
+                .build()
+        );
     }
 
     // One iteration of reporting this scope and all its subscopes
@@ -391,7 +381,6 @@ class ScopeImpl implements Scope {
     }
 
     static class Registry {
-        final Object allocationLock = new Object();
         Map<String, ScopeImpl> subscopes = new ConcurrentHashMap<>();
     }
 }


### PR DESCRIPTION
In our application the metric tags are dynamic, so we end up calling ScopeImpl#tagged api for the subscope, each time a metric in emitted. We have upto 10^5 metric series in one environment. The global lock is resulting in many threads in blocked state. 

Moving to concurrentHashMap, we atmost put a read-write lock on a particular bucket rather than whole object. 