### PR TITLE
Fixing excessive memory allocations within M3Reporter flushing pipeline

### DIFF
--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -29,6 +29,7 @@ import com.uber.m3.tally.StatsReporter;
 import com.uber.m3.tally.m3.thrift.TCalcTransport;
 import com.uber.m3.tally.m3.thrift.TMultiUdpClient;
 import com.uber.m3.tally.m3.thrift.TUdpClient;
+import com.uber.m3.tally.m3.thrift.TUdpTransport;
 import com.uber.m3.thrift.gen.CountValue;
 import com.uber.m3.thrift.gen.GaugeValue;
 import com.uber.m3.thrift.gen.M3;
@@ -86,7 +87,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
     private static final int DEFAULT_METRIC_SIZE = 100;
     private static final int DEFAULT_MAX_QUEUE_SIZE = 4096;
-    private static final int DEFAULT_MAX_PACKET_SIZE = 32768;
+    private static final int DEFAULT_MAX_PACKET_SIZE = TUdpTransport.UDP_DATA_PAYLOAD_MAX_SIZE;
 
     private static final int THREAD_POOL_SIZE = 10;
 

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
@@ -52,14 +52,17 @@ public class TUdpClient extends TUdpTransport implements AutoCloseable {
     @Override
     public void flush() throws TTransportException {
         synchronized (sendLock) {
-            byte[] bytes = new byte[MAX_BUFFER_SIZE];
+            // Fix the length of the buffer written so far
             int length = writeBuffer.position();
 
+            // Flip the buffer to write it over the wire in the reversed
+            // ordering
             writeBuffer.flip();
-            writeBuffer.get(bytes, 0, length);
 
             try {
-                socket.send(new DatagramPacket(bytes, length));
+                socket.send(
+                    new DatagramPacket(writeBuffer.array(), length)
+                );
             } catch (IOException e) {
                 throw new TTransportException(e);
             } finally {

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -20,6 +20,7 @@
 
 package com.uber.m3.tally.m3.thrift;
 
+import org.apache.http.annotation.GuardedBy;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 
@@ -40,7 +41,11 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
     public final Object sendLock = new Object();
 
     protected final DatagramSocket socket = new DatagramSocket(null);
+
+    @GuardedBy("receiveLock")
     protected ByteBuffer receiveBuffer;
+
+    @GuardedBy("sendLock")
     protected ByteBuffer writeBuffer;
 
     protected SocketAddress socketAddress;

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -35,7 +35,9 @@ import java.nio.ByteBuffer;
  * Abstract class that supports Thrift UDP functionality.
  */
 public abstract class TUdpTransport extends TTransport implements AutoCloseable {
-    public static final int MAX_BUFFER_SIZE = 65536;
+    // NOTE: This is the maximum size of a single UDP packet's payload in IPv4
+    //       which is set at 65,535 = 8 bytes (header) + 65,527 bytes (data)
+    public static final int UDP_DATA_PAYLOAD_MAX_SIZE = 65527;
 
     public final Object receiveLock = new Object();
     public final Object sendLock = new Object();
@@ -53,9 +55,9 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
     protected TUdpTransport(SocketAddress socketAddress) throws SocketException {
         this.socketAddress = socketAddress;
 
-        writeBuffer = ByteBuffer.allocate(MAX_BUFFER_SIZE);
+        writeBuffer = ByteBuffer.allocate(UDP_DATA_PAYLOAD_MAX_SIZE);
 
-        receiveBuffer = ByteBuffer.allocate(MAX_BUFFER_SIZE);
+        receiveBuffer = ByteBuffer.allocate(UDP_DATA_PAYLOAD_MAX_SIZE);
         receiveBuffer.flip();
     }
 
@@ -82,7 +84,7 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
             if (!receiveBuffer.hasRemaining()) {
                 // Use ByteBuffer's backing array and manually set the position and limit to
                 // avoid having to re-copy contents to a new array via `get`
-                DatagramPacket packet = new DatagramPacket(receiveBuffer.array(), MAX_BUFFER_SIZE);
+                DatagramPacket packet = new DatagramPacket(receiveBuffer.array(), UDP_DATA_PAYLOAD_MAX_SIZE);
 
                 try {
                     socket.receive(packet);
@@ -109,11 +111,11 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
         }
 
         synchronized (sendLock) {
-            if (writeBuffer.position() + length > MAX_BUFFER_SIZE) {
+            if (writeBuffer.position() + length > UDP_DATA_PAYLOAD_MAX_SIZE) {
                 throw new TTransportException(
                     String.format("Message size too large: %d is greater than available size %d",
                         length,
-                        MAX_BUFFER_SIZE - writeBuffer.position()
+                        UDP_DATA_PAYLOAD_MAX_SIZE - writeBuffer.position()
                     )
                 );
             }


### PR DESCRIPTION
This is putting severe pressure on our service currently (T5668949).

Primary factors for that are discrepancies between `M3Reporter.DEFAULT_MAX_PACKET_SIZE` and `TUdpTransport.MAX_BUFFER_SIZE` triggering allocations of 65kb buffer for the payload of 1.5kb (v0.4.1).

This change:

1.  Eliminates those unnecessary allocations altogether
2. Re-aligns `M3Reporter` buffer size along with `TUdpTransport` one tying it to max UDP data payload size