### PR TITLE
Refactored `M3Reporter` implementation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,10 +57,12 @@ allprojects {
 
     repositories {
         mavenCentral()
+        jcenter()
     }
 
     dependencies {
         testCompile('junit:junit:4.12')
+        testCompile "org.mockito:mockito-core:1.+"
     }
 
     ext.ossrhUsername = System.getenv('OSSRH_JIRA_USERNAME')

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -431,6 +431,11 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
     }
 
     private void queueSizedMetric(SizedMetric sizedMetric) {
+        // Short-circuit if already shutdown
+        if (isShutdown.get()) {
+            return;
+        }
+
         try {
             metricQueue.put(sizedMetric);
         } catch (InterruptedException e) {

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -463,7 +463,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
                     // When this reporter is closed, shutdownNow will be called on the executor,
                     // which will interrupt this thread and proceed to the `InterruptedException`
                     // catch block.
-                    SizedMetric sizedMetric = metricQueue.poll(maxBufferingDelay, TimeUnit.MILLISECONDS);
+                    SizedMetric sizedMetric = metricQueue.poll(maxBufferingDelay.toMillis(), TimeUnit.MILLISECONDS);
 
                     // Drop metrics that came in after close
                     if (sizedMetric == SizedMetric.CLOSE) {

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -65,7 +65,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(M3Reporter.class);
 
-    public static final int MAX_DELAY_BEFORE_FLUSHING_MILLIS = 1_000;
+    private static final int MAX_DELAY_BEFORE_FLUSHING_MILLIS = 1_000;
 
     private static final int MAX_PROCESSOR_WAIT_ON_CLOSE_MILLIS = 5_000;
 
@@ -78,7 +78,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
     private static final int NUM_PROCESSORS = 1;
 
-    private final static ThreadLocal<SerializedPayloadSizeEstimator> PAYLOAD_SIZE_ESTIMATOR =
+    private static final ThreadLocal<SerializedPayloadSizeEstimator> PAYLOAD_SIZE_ESTIMATOR =
             ThreadLocal.withInitial(SerializedPayloadSizeEstimator::new);
 
     private M3.Client client;

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -87,8 +87,6 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
     private static final int DEFAULT_MAX_QUEUE_SIZE = 4096;
     private static final int DEFAULT_MAX_PACKET_SIZE = TUdpTransport.UDP_DATA_PAYLOAD_MAX_SIZE;
 
-    private static final int THREAD_POOL_SIZE = 10;
-
     private static final int EMIT_METRIC_BATCH_OVERHEAD = 19;
     private static final int MIN_METRIC_BUCKET_ID_TAG_LENGTH = 4;
 
@@ -146,7 +144,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
             metricQueue = new LinkedBlockingQueue<>(builder.maxQueueSize);
 
-            executor = builder.executor;
+            executor = builder.executor != null ? builder.executor : Executors.newFixedThreadPool(NUM_PROCESSORS);
 
             for (int i = 0; i < NUM_PROCESSORS; ++i) {
                 addAndRunProcessor(builder.metricTagSet);
@@ -565,7 +563,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
         protected SocketAddress[] socketAddresses;
         protected String service;
         protected String env;
-        protected ExecutorService executor = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
+        protected ExecutorService executor;
         // Non-generic EMPTY ImmutableMap will never contain any elements
         @SuppressWarnings("unchecked")
         protected ImmutableMap<String, String> commonTags = ImmutableMap.EMPTY;

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -20,12 +20,24 @@
 
 package com.uber.m3.tally.m3;
 
-import com.uber.m3.tally.*;
+import com.uber.m3.tally.BucketPair;
+import com.uber.m3.tally.BucketPairImpl;
+import com.uber.m3.tally.Buckets;
+import com.uber.m3.tally.Capabilities;
+import com.uber.m3.tally.CapableOf;
+import com.uber.m3.tally.StatsReporter;
 import com.uber.m3.tally.m3.thrift.TCalcTransport;
 import com.uber.m3.tally.m3.thrift.TMultiUdpClient;
 import com.uber.m3.tally.m3.thrift.TUdpClient;
 import com.uber.m3.tally.m3.thrift.TUdpTransport;
-import com.uber.m3.thrift.gen.*;
+import com.uber.m3.thrift.gen.CountValue;
+import com.uber.m3.thrift.gen.GaugeValue;
+import com.uber.m3.thrift.gen.M3;
+import com.uber.m3.thrift.gen.Metric;
+import com.uber.m3.thrift.gen.MetricBatch;
+import com.uber.m3.thrift.gen.MetricTag;
+import com.uber.m3.thrift.gen.MetricValue;
+import com.uber.m3.thrift.gen.TimerValue;
 import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
 import org.apache.http.annotation.NotThreadSafe;
@@ -163,7 +175,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
     private int calculatePayloadCapacity(int maxPacketSizeBytes, Set<MetricTag> commonTags) {
         MetricBatch metricBatch = new MetricBatch();
         metricBatch.setCommonTags(commonTags);
-        metricBatch.setMetrics(new ArrayList<Metric>());
+        metricBatch.setMetrics(new ArrayList<>());
 
         int size = PAYLOAD_SIZE_ESTIMATOR.get().calculateSize(metricBatch);
 

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -77,7 +77,9 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
     private static final Logger LOG = LoggerFactory.getLogger(M3Reporter.class);
 
-    private static final int MAX_PROCESSOR_WAIT_ON_CLOSE_MILLIS = 1000;
+    public static final int MAX_DELAY_BEFORE_FLUSHING_MILLIS = 1_000;
+
+    private static final int MAX_PROCESSOR_WAIT_ON_CLOSE_MILLIS = 5_000;
 
     private static final int DEFAULT_METRIC_SIZE = 100;
     private static final int DEFAULT_MAX_QUEUE_SIZE = 4096;
@@ -575,7 +577,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
         protected boolean includeHost = false;
         protected int maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
         protected int maxPacketSizeBytes = DEFAULT_MAX_PACKET_SIZE;
-        protected int maxProcessorWaitUntilFlushMillis = 10_000;
+        protected int maxProcessorWaitUntilFlushMillis = MAX_DELAY_BEFORE_FLUSHING_MILLIS;
         protected String histogramBucketIdName = DEFAULT_HISTOGRAM_BUCKET_ID_NAME;
         protected String histogramBucketName = DEFAULT_HISTOGRAM_BUCKET_NAME;
         protected int histogramBucketTagPrecision = DEFAULT_HISTOGRAM_BUCKET_TAG_PRECISION;

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
@@ -24,6 +24,7 @@ import org.apache.thrift.transport.TTransportException;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
+import java.net.DatagramSocket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 
@@ -38,6 +39,11 @@ public class TUdpClient extends TUdpTransport implements AutoCloseable {
      */
     public TUdpClient(SocketAddress socketAddress) throws SocketException {
         super(socketAddress);
+    }
+
+    // NOTE: Thi is used in tests ONLY
+    TUdpClient(SocketAddress socketAddress, DatagramSocket socket) {
+        super(socketAddress, socket);
     }
 
     @Override

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
@@ -54,13 +54,11 @@ public class TUdpClient extends TUdpTransport implements AutoCloseable {
         synchronized (sendLock) {
             // Fix the length of the buffer written so far
             int length = writeBuffer.position();
-
-            // Flip the buffer to write it over the wire in the reversed
-            // ordering
-            writeBuffer.flip();
-
             try {
                 socket.send(
+                    // NOTE: Since flushing is a blocking operation we're deliberately
+                    //       avoiding additional allocations and simply re-use the same buffer for IO
+                    //       directly
                     new DatagramPacket(writeBuffer.array(), length)
                 );
             } catch (IOException e) {

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
@@ -41,7 +41,7 @@ public class TUdpClient extends TUdpTransport implements AutoCloseable {
         super(socketAddress);
     }
 
-    // NOTE: Thi is used in tests ONLY
+    // NOTE: This is used in tests ONLY
     TUdpClient(SocketAddress socketAddress, DatagramSocket socket) {
         super(socketAddress, socket);
     }

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
@@ -58,14 +58,12 @@ public class TUdpClient extends TUdpTransport implements AutoCloseable {
     @Override
     public void flush() throws TTransportException {
         synchronized (sendLock) {
-            // Fix the length of the buffer written so far
-            int length = writeBuffer.position();
             try {
                 socket.send(
                     // NOTE: Since flushing is a blocking operation we're deliberately
                     //       avoiding additional allocations and simply re-use the same buffer for IO
                     //       directly
-                    new DatagramPacket(writeBuffer.array(), length)
+                    new DatagramPacket(writeBuffer.array(), writeBuffer.position())
                 );
             } catch (IOException e) {
                 throw new TTransportException(e);

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -42,7 +42,7 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
     protected final Object receiveLock = new Object();
     protected final Object sendLock = new Object();
 
-    protected final DatagramSocket socket = new DatagramSocket(null);
+    protected final DatagramSocket socket;
 
     @GuardedBy("receiveLock")
     protected ByteBuffer receiveBuffer;
@@ -52,11 +52,17 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
 
     protected SocketAddress socketAddress;
 
-    protected TUdpTransport(SocketAddress socketAddress) throws SocketException {
+    // NOTE: This is used in tests
+    TUdpTransport(SocketAddress socketAddress, DatagramSocket socket) {
         this.socketAddress = socketAddress;
+        this.socket = socket;
 
-        writeBuffer = ByteBuffer.allocate(UDP_DATA_PAYLOAD_MAX_SIZE);
-        receiveBuffer = ByteBuffer.allocate(UDP_DATA_PAYLOAD_MAX_SIZE);
+        this.writeBuffer = ByteBuffer.allocate(UDP_DATA_PAYLOAD_MAX_SIZE);
+        this.receiveBuffer = ByteBuffer.allocate(UDP_DATA_PAYLOAD_MAX_SIZE);
+    }
+
+    protected TUdpTransport(SocketAddress socketAddress) throws SocketException {
+        this(socketAddress, new DatagramSocket(null));
     }
 
     @Override

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -39,18 +39,18 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
     //       which is set at 65,535 = 8 bytes (header) + 65,527 bytes (data)
     public static final int UDP_DATA_PAYLOAD_MAX_SIZE = 65527;
 
-    private final Object receiveLock = new Object();
     protected final Object sendLock = new Object();
 
+    protected final SocketAddress socketAddress;
     protected final DatagramSocket socket;
-
-    @GuardedBy("receiveLock")
-    protected ByteBuffer receiveBuffer;
 
     @GuardedBy("sendLock")
     protected ByteBuffer writeBuffer;
 
-    protected SocketAddress socketAddress;
+    private final Object receiveLock = new Object();
+
+    @GuardedBy("receiveLock")
+    private ByteBuffer receiveBuffer;
 
     // NOTE: This is used in tests
     TUdpTransport(SocketAddress socketAddress, DatagramSocket socket) {

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -59,6 +59,10 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
 
         this.writeBuffer = ByteBuffer.allocate(UDP_DATA_PAYLOAD_MAX_SIZE);
         this.receiveBuffer = ByteBuffer.allocate(UDP_DATA_PAYLOAD_MAX_SIZE);
+
+        // Resets receiving buffer to 0, to make sure it isn't readable
+        // until it would be first written
+        this.receiveBuffer.limit(0);
     }
 
     protected TUdpTransport(SocketAddress socketAddress) throws SocketException {

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -39,7 +39,7 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
     //       which is set at 65,535 = 8 bytes (header) + 65,527 bytes (data)
     public static final int UDP_DATA_PAYLOAD_MAX_SIZE = 65527;
 
-    protected final Object receiveLock = new Object();
+    private final Object receiveLock = new Object();
     protected final Object sendLock = new Object();
 
     protected final DatagramSocket socket;

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -39,8 +39,8 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
     //       which is set at 65,535 = 8 bytes (header) + 65,527 bytes (data)
     public static final int UDP_DATA_PAYLOAD_MAX_SIZE = 65527;
 
-    public final Object receiveLock = new Object();
-    public final Object sendLock = new Object();
+    protected final Object receiveLock = new Object();
+    protected final Object sendLock = new Object();
 
     protected final DatagramSocket socket = new DatagramSocket(null);
 
@@ -56,9 +56,7 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
         this.socketAddress = socketAddress;
 
         writeBuffer = ByteBuffer.allocate(UDP_DATA_PAYLOAD_MAX_SIZE);
-
         receiveBuffer = ByteBuffer.allocate(UDP_DATA_PAYLOAD_MAX_SIZE);
-        receiveBuffer.flip();
     }
 
     @Override
@@ -129,21 +127,29 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
 
     @Override
     public int getBytesRemainingInBuffer() {
-        return receiveBuffer.remaining();
+        synchronized (receiveLock) {
+            return receiveBuffer.remaining();
+        }
     }
 
     @Override
     public byte[] getBuffer() {
-        return receiveBuffer.array();
+        synchronized (receiveLock) {
+            return receiveBuffer.array();
+        }
     }
 
     @Override
     public int getBufferPosition() {
-        return receiveBuffer.position();
+        synchronized (receiveLock) {
+            return receiveBuffer.position();
+        }
     }
 
     @Override
     public void consumeBuffer(int length) {
-        receiveBuffer.position(receiveBuffer.position() + length);
+        synchronized (receiveLock) {
+            receiveBuffer.position(receiveBuffer.position() + length);
+        }
     }
 }

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -23,16 +23,8 @@ package com.uber.m3.tally.m3;
 import com.uber.m3.tally.Buckets;
 import com.uber.m3.tally.CapableOf;
 import com.uber.m3.tally.DurationBuckets;
-
 import com.uber.m3.tally.ValueBuckets;
-import com.uber.m3.thrift.gen.CountValue;
-import com.uber.m3.thrift.gen.GaugeValue;
-import com.uber.m3.thrift.gen.Metric;
-import com.uber.m3.thrift.gen.MetricBatch;
-import com.uber.m3.thrift.gen.MetricTag;
-import com.uber.m3.thrift.gen.MetricValue;
-import com.uber.m3.thrift.gen.TimerValue;
-
+import com.uber.m3.thrift.gen.*;
 import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
 import org.junit.BeforeClass;
@@ -45,12 +37,8 @@ import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Phaser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class M3ReporterTest {
     private static double EPSILON = 1e-9;

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
@@ -28,7 +28,6 @@ import org.apache.thrift.transport.TTransportException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Phaser;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
@@ -63,6 +63,7 @@ public class MockM3Service implements M3.Iface {
         }
     }
 
+    @Override
     public void emitMetricBatch(MetricBatch batch) throws TTransportException {
         lock.writeLock().lock();
 

--- a/m3/src/test/java/com/uber/m3/tally/m3/thrift/TUdpClientTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/thrift/TUdpClientTest.java
@@ -1,3 +1,23 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package com.uber.m3.tally.m3.thrift;
 
 import org.apache.commons.codec.Charsets;
@@ -10,9 +30,6 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Stream;
 
 import static org.mockito.Mockito.*;
@@ -62,7 +79,6 @@ public class TUdpClientTest {
                 new String(sentPacket.getData(), sentPacket.getOffset(), sentPacket.getLength(), Charsets.US_ASCII)
         );
     }
-
 
     private static TUdpClient createUdpClient(DatagramSocket mockedSocket) {
         return new TUdpClient(InetSocketAddress.createUnresolved("0.0.0.0", 0), mockedSocket);

--- a/m3/src/test/java/com/uber/m3/tally/m3/thrift/TUdpClientTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/thrift/TUdpClientTest.java
@@ -11,7 +11,9 @@ import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.mockito.Mockito.*;
 
@@ -23,25 +25,22 @@ public class TUdpClientTest {
 
         TUdpClient client = createUdpClient(mockedSocket);
 
-        byte[] writtenBytes = "0xDEEDDEED".getBytes(Charsets.US_ASCII);
+        byte[][] payloads =
+                Stream.of("0xDEEDDEED", "0xABBAABBA")
+                    .map(p -> p.getBytes(Charsets.US_ASCII))
+                    .toArray(byte[][]::new);
 
-        client.write(writtenBytes);
-        client.flush();
+        for (byte[] writtenBytes : payloads) {
+            client.write(writtenBytes);
+            client.flush();
 
-        // Writes could only be asserted one by one, due to underlying write buffer sharing within the
-        // {@code TUdpClient}
-        assertBytesWritten(mockedSocket, writtenBytes);
+            // Writes could only be asserted one by one, due to underlying write buffer sharing within the
+            // {@code TUdpClient}
+            assertBytesWritten(mockedSocket, writtenBytes);
 
-        // We have to reset mocks between invocations
-        reset(mockedSocket);
-
-        // Validate writes after flush
-        byte[] anotherWrittenBytes = "0xABBAABBA".getBytes(Charsets.US_ASCII);
-
-        client.write(anotherWrittenBytes);
-        client.flush();
-
-        assertBytesWritten(mockedSocket, anotherWrittenBytes);
+            // We have to reset mocks between invocations
+            reset(mockedSocket);
+        }
     }
 
     private static void assertBytesWritten(DatagramSocket mockedSocket, byte[] expectedPayload) throws IOException {

--- a/m3/src/test/java/com/uber/m3/tally/m3/thrift/TUdpClientTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/thrift/TUdpClientTest.java
@@ -1,0 +1,72 @@
+package com.uber.m3.tally.m3.thrift;
+
+import org.apache.commons.codec.Charsets;
+import org.apache.thrift.transport.TTransportException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+public class TUdpClientTest {
+
+    @Test
+    public void testWritingAfterFlushingSequence() throws TTransportException, IOException {
+        DatagramSocket mockedSocket = mock(DatagramSocket.class);
+
+        TUdpClient client = createUdpClient(mockedSocket);
+
+        byte[] writtenBytes = "0xDEEDDEED".getBytes(Charsets.US_ASCII);
+
+        client.write(writtenBytes);
+        client.flush();
+
+        // Writes could only be asserted one by one, due to underlying write buffer sharing within the
+        // {@code TUdpClient}
+        assertBytesWritten(mockedSocket, writtenBytes);
+
+        // We have to reset mocks between invocations
+        reset(mockedSocket);
+
+        // Validate writes after flush
+        byte[] anotherWrittenBytes = "0xABBAABBA".getBytes(Charsets.US_ASCII);
+
+        client.write(anotherWrittenBytes);
+        client.flush();
+
+        assertBytesWritten(mockedSocket, anotherWrittenBytes);
+    }
+
+    private static void assertBytesWritten(DatagramSocket mockedSocket, byte[] expectedPayload) throws IOException {
+        ArgumentCaptor<DatagramPacket> argCaptor = ArgumentCaptor.forClass(DatagramPacket.class);
+
+        verify(mockedSocket, times(1))
+                .send(argCaptor.capture());
+
+        DatagramPacket sentPacket = argCaptor.getValue();
+
+        // Validate that outgoing buffer is of `TUdpClient.UDP_DATA_PAYLOAD_MAX_SIZE` size
+        Assert.assertEquals(TUdpClient.UDP_DATA_PAYLOAD_MAX_SIZE, sentPacket.getData().length);
+
+        // Validate actual data being written to the socket
+        Assert.assertEquals(expectedPayload.length, sentPacket.getLength());
+        Assert.assertEquals(0, sentPacket.getOffset());
+        Assert.assertEquals(
+                new String(expectedPayload, Charsets.US_ASCII),
+                new String(sentPacket.getData(), sentPacket.getOffset(), sentPacket.getLength(), Charsets.US_ASCII)
+        );
+    }
+
+
+    private static TUdpClient createUdpClient(DatagramSocket mockedSocket) {
+        return new TUdpClient(InetSocketAddress.createUnresolved("0.0.0.0", 0), mockedSocket);
+    }
+
+}


### PR DESCRIPTION
1. Cleaned up `TUdpClient` implementation and added tests
2. Refactored `M3Reporter` implementation
  - Cleaned up/abstracted common ports
  - Abolished unnecessary locking
  - Made sure that flushing is guaranteed to happen at most `MAX_DELAY` ms
  - Added proper shutdown short-circuiting
3. Fixed tests misusing `Phaser` (and flakily failing) 