### PR TITLE
Fixing improper payload size estimation

### DIFF
--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -93,7 +93,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
     private static final int DEFAULT_METRIC_SIZE = 100;
     private static final int DEFAULT_MAX_QUEUE_SIZE = 4096;
-    private static final int DEFAULT_MAX_PACKET_SIZE = TUdpTransport.UDP_DATA_PAYLOAD_MAX_SIZE;
+    private static final int DEFAULT_MAX_PACKET_SIZE = TUdpTransport.PACKET_DATA_PAYLOAD_MAX_SIZE;
 
     private static final int EMIT_METRIC_BATCH_OVERHEAD = 19;
     private static final int MIN_METRIC_BUCKET_ID_TAG_LENGTH = 4;

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -89,13 +89,15 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
     private static final int MAX_DELAY_BEFORE_FLUSHING_MILLIS = 1_000;
 
-    private static final int MAX_PROCESSOR_WAIT_ON_CLOSE_MILLIS = 1_000;
+    private static final int MAX_PROCESSOR_WAIT_ON_CLOSE_MILLIS = 5_000;
 
     private static final int DEFAULT_METRIC_SIZE = 100;
     private static final int DEFAULT_MAX_QUEUE_SIZE = 4096;
     private static final int DEFAULT_MAX_PACKET_SIZE = TUdpTransport.PACKET_DATA_PAYLOAD_MAX_SIZE;
 
-    private static final int EMIT_METRIC_BATCH_OVERHEAD = 19;
+    // NOTE: 256 bytes of overhead is reserved for Thrift metadata within UDP datagram payload
+    private static final int THRIFT_METADATA_OVERHEAD = 256;
+
     private static final int MIN_METRIC_BUCKET_ID_TAG_LENGTH = 4;
 
     private static final int NUM_PROCESSORS = 1;
@@ -177,12 +179,13 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
         metricBatch.setCommonTags(commonTags);
         metricBatch.setMetrics(new ArrayList<>());
 
-        int size = PAYLOAD_SIZE_ESTIMATOR.get().calculateSize(metricBatch);
+        M3.emitMetricBatch_args request =
+            new M3.emitMetricBatch_args()
+                .setBatch(metricBatch);
 
-        int numOverheadBytes = EMIT_METRIC_BATCH_OVERHEAD + size;
+        int thriftRequestShellSize = PAYLOAD_SIZE_ESTIMATOR.get().calculateSize(request);
 
-        int payloadCapacity = maxPacketSizeBytes - numOverheadBytes;
-
+        int payloadCapacity = maxPacketSizeBytes - (THRIFT_METADATA_OVERHEAD + thriftRequestShellSize);
         if (payloadCapacity <= 0) {
             throw new IllegalArgumentException("Common tags serialized size exceeds packet size");
         }

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -41,7 +41,6 @@ import com.uber.m3.thrift.gen.TimerValue;
 import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
 import org.apache.http.annotation.NotThreadSafe;
-import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -96,7 +95,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
     private static final int DEFAULT_MAX_PACKET_SIZE = TUdpTransport.PACKET_DATA_PAYLOAD_MAX_SIZE;
 
     // NOTE: 256 bytes of overhead is reserved for Thrift metadata within UDP datagram payload
-    private static final int THRIFT_METADATA_OVERHEAD = 256;
+    private static final int THRIFT_METADATA_PADDING = 256;
 
     private static final int MIN_METRIC_BUCKET_ID_TAG_LENGTH = 4;
 
@@ -179,13 +178,9 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
         metricBatch.setCommonTags(commonTags);
         metricBatch.setMetrics(new ArrayList<>());
 
-        M3.emitMetricBatch_args request =
-            new M3.emitMetricBatch_args()
-                .setBatch(metricBatch);
+        int thriftRequestShellSize = PAYLOAD_SIZE_ESTIMATOR.get().evaluateThriftRequestWireSize(metricBatch);
 
-        int thriftRequestShellSize = PAYLOAD_SIZE_ESTIMATOR.get().calculateSize(request);
-
-        int payloadCapacity = maxPacketSizeBytes - (THRIFT_METADATA_OVERHEAD + thriftRequestShellSize);
+        int payloadCapacity = maxPacketSizeBytes - (THRIFT_METADATA_PADDING + thriftRequestShellSize);
         if (payloadCapacity <= 0) {
             throw new IllegalArgumentException("Common tags serialized size exceeds packet size");
         }
@@ -321,7 +316,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
         Metric metric = newMetric(name, tags, metricValue);
 
-        queueSizedMetric(new SizedMetric(metric, PAYLOAD_SIZE_ESTIMATOR.get().calculateSize(metric)));
+        queueSizedMetric(new SizedMetric(metric, PAYLOAD_SIZE_ESTIMATOR.get().evaluateByteSize(metric)));
     }
 
     @Override
@@ -334,7 +329,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
         Metric metric = newMetric(name, tags, metricValue);
 
-        queueSizedMetric(new SizedMetric(metric, PAYLOAD_SIZE_ESTIMATOR.get().calculateSize(metric)));
+        queueSizedMetric(new SizedMetric(metric, PAYLOAD_SIZE_ESTIMATOR.get().evaluateByteSize(metric)));
     }
 
     @Override
@@ -443,7 +438,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
         Metric metric = newMetric(name, tags, metricValue);
 
-        queueSizedMetric(new SizedMetric(metric, PAYLOAD_SIZE_ESTIMATOR.get().calculateSize(metric)));
+        queueSizedMetric(new SizedMetric(metric, PAYLOAD_SIZE_ESTIMATOR.get().evaluateByteSize(metric)));
     }
 
     private Metric newMetric(String name, Map<String, String> tags, MetricValue metricValue) {
@@ -580,12 +575,24 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
         private final TProtocol calculatingPhonyProtocol =
                 new TCompactProtocol.Factory().getProtocol(calculatingPhonyTransport);
 
-        public int calculateSize(TBase<?, ?> metric) {
+        private final M3.Client phonyClient = new M3.Client(calculatingPhonyProtocol);
+
+        public int evaluateThriftRequestWireSize(MetricBatch metricBatch) {
+            try {
+                phonyClient.emitMetricBatch(metricBatch);
+                return calculatingPhonyTransport.getSizeAndReset();
+            } catch (TException e) {
+                LOG.warn("Unable to calculate metric batch size", e);
+                throw new RuntimeException(e);
+            }
+        }
+
+        public int evaluateByteSize(Metric metric) {
             try {
                 metric.write(calculatingPhonyProtocol);
                 return calculatingPhonyTransport.getSizeAndReset();
             } catch (TException e) {
-                LOG.warn("Unable to calculate metric batch size. Defaulting to: " + DEFAULT_METRIC_SIZE);
+                LOG.warn("Unable to calculate metric batch size. Defaulting to: " + DEFAULT_METRIC_SIZE, e);
                 return DEFAULT_METRIC_SIZE;
             }
         }

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -36,10 +36,10 @@ import java.nio.ByteBuffer;
  */
 public abstract class TUdpTransport extends TTransport implements AutoCloseable {
     // NOTE: This is the maximum size of a single UDP packet's payload in IPv4
-    //       which is set at 65,535, we reserve 1024 byte of buffering for various
+    //       which is set at 65,535, we reserve 512 byte of buffering for various
     //       network configurations therefore setting payload size to be no more than:
-    //       65535 - 1024 = 64511 bytes
-    public static final int PACKET_DATA_PAYLOAD_MAX_SIZE = 64511;
+    //       65535 - 512 = 65023 bytes
+    public static final int PACKET_DATA_PAYLOAD_MAX_SIZE = 65023;
 
     protected final Object sendLock = new Object();
 

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -36,8 +36,10 @@ import java.nio.ByteBuffer;
  */
 public abstract class TUdpTransport extends TTransport implements AutoCloseable {
     // NOTE: This is the maximum size of a single UDP packet's payload in IPv4
-    //       which is set at 65,535 = 8 bytes (header) + 65,527 bytes (data)
-    public static final int UDP_DATA_PAYLOAD_MAX_SIZE = 65527;
+    //       which is set at 65,535, we reserve 1024 byte of buffering for various
+    //       network configurations therefore setting payload size to be no more than:
+    //       65535 - 1024 = 64511 bytes
+    public static final int PACKET_DATA_PAYLOAD_MAX_SIZE = 64511;
 
     protected final Object sendLock = new Object();
 
@@ -57,8 +59,8 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
         this.socketAddress = socketAddress;
         this.socket = socket;
 
-        this.writeBuffer = ByteBuffer.allocate(UDP_DATA_PAYLOAD_MAX_SIZE);
-        this.receiveBuffer = ByteBuffer.allocate(UDP_DATA_PAYLOAD_MAX_SIZE);
+        this.writeBuffer = ByteBuffer.allocate(PACKET_DATA_PAYLOAD_MAX_SIZE);
+        this.receiveBuffer = ByteBuffer.allocate(PACKET_DATA_PAYLOAD_MAX_SIZE);
 
         // Resets receiving buffer to 0, to make sure it isn't readable
         // until it would be first written
@@ -92,7 +94,7 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
             if (!receiveBuffer.hasRemaining()) {
                 // Use ByteBuffer's backing array and manually set the position and limit to
                 // avoid having to re-copy contents to a new array via `get`
-                DatagramPacket packet = new DatagramPacket(receiveBuffer.array(), UDP_DATA_PAYLOAD_MAX_SIZE);
+                DatagramPacket packet = new DatagramPacket(receiveBuffer.array(), PACKET_DATA_PAYLOAD_MAX_SIZE);
 
                 try {
                     socket.receive(packet);
@@ -119,11 +121,11 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
         }
 
         synchronized (sendLock) {
-            if (writeBuffer.position() + length > UDP_DATA_PAYLOAD_MAX_SIZE) {
+            if (writeBuffer.position() + length > PACKET_DATA_PAYLOAD_MAX_SIZE) {
                 throw new TTransportException(
                     String.format("Message size too large: %d is greater than available size %d",
                         length,
-                        UDP_DATA_PAYLOAD_MAX_SIZE - writeBuffer.position()
+                        PACKET_DATA_PAYLOAD_MAX_SIZE - writeBuffer.position()
                     )
                 );
             }

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Server.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Server.java
@@ -31,9 +31,13 @@ import org.apache.thrift.transport.TTransportException;
 
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class MockM3Server {
+    private static final Duration MAX_WAIT_TIMEOUT = Duration.ofSeconds(30);
+
     private final CountDownLatch expectedMetricsLatch;
 
     private TProcessor processor;
@@ -78,7 +82,7 @@ public class MockM3Server {
     }
 
     public void awaitAndClose() throws InterruptedException {
-        expectedMetricsLatch.await();
+        expectedMetricsLatch.await(MAX_WAIT_TIMEOUT.getSeconds(), TimeUnit.SECONDS);
         transport.close();
     }
 

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
@@ -51,16 +51,6 @@ public class MockM3Service implements M3.Iface {
         }
     }
 
-    public List<Metric> getMetrics() {
-        lock.readLock().lock();
-
-        try {
-            return metrics;
-        } finally {
-            lock.readLock().unlock();
-        }
-    }
-
     @Override
     public void emitMetricBatch(MetricBatch batch) throws TTransportException {
         lock.writeLock().lock();
@@ -74,7 +64,5 @@ public class MockM3Service implements M3.Iface {
         }
 
         lock.writeLock().unlock();
-
-        throw new TTransportException(TTransportException.END_OF_FILE, "complete");
     }
 }

--- a/m3/src/test/java/com/uber/m3/tally/m3/thrift/TUdpClientTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/thrift/TUdpClientTest.java
@@ -69,7 +69,7 @@ public class TUdpClientTest {
         DatagramPacket sentPacket = argCaptor.getValue();
 
         // Validate that outgoing buffer is of `TUdpClient.UDP_DATA_PAYLOAD_MAX_SIZE` size
-        Assert.assertEquals(TUdpClient.UDP_DATA_PAYLOAD_MAX_SIZE, sentPacket.getData().length);
+        Assert.assertEquals(TUdpClient.PACKET_DATA_PAYLOAD_MAX_SIZE, sentPacket.getData().length);
 
         // Validate actual data being written to the socket
         Assert.assertEquals(expectedPayload.length, sentPacket.getLength());


### PR DESCRIPTION
Previously Thrift protocol overhead was factored using constant `19` which in reality is `21` right now and due to previous changes in the target buffer payload size M3 reporter started to hit that exception pretty consistently with metrics payload exceeding size of the buffer allocated obliterating our metrics.

1. Added proper size estimation: using the same client being used for actual payload serialization over the wire; 
2. Removed magic constant, added padding of 256 bytes for any future metadata being added
3. Added test overflowing single datagram buffer size with metrics' (size) small enough to hit future potential discrepancies between max UDP datagram packet size and `M3Reporter` configuration