### PR TITLE
Java 8 code cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: required
 
 language: java
 
-# This project is aimed to be JRE7-compatible. However, there
-# are issues testing against oraclejdk7 in Travis:
-# https://github.com/travis-ci/travis-ci/issues/7884
+# This project is JRE8-compatible.
 jdk:
   - openjdk8
   - oraclejdk8

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -6,7 +6,7 @@ This document summarizes information relevant to Java tally contributors.
 
 ### Prerequisites
 In order to build this project, you must have:
-- JDK-7 or later
+- JDK-8 or later
 - Apache Thrift 0.9.x -- only if you plan to make changes to Thrift files and recompile (regenerate) source files
 
 ### Building and testing

--- a/core/src/main/java/com/uber/m3/tally/BucketPairImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/BucketPairImpl.java
@@ -28,10 +28,10 @@ import java.util.Collections;
  * Default implementation of a {@link BucketPair}
  */
 public class BucketPairImpl implements BucketPair {
-    private double lowerBoundValue;
-    private double upperBoundValue;
-    private Duration lowerBoundDuration;
-    private Duration upperBoundDuration;
+    private final double lowerBoundValue;
+    private final double upperBoundValue;
+    private final Duration lowerBoundDuration;
+    private final Duration upperBoundDuration;
 
     public BucketPairImpl(
         double lowerBoundValue,

--- a/core/src/main/java/com/uber/m3/tally/CapableOf.java
+++ b/core/src/main/java/com/uber/m3/tally/CapableOf.java
@@ -29,8 +29,8 @@ public class CapableOf implements Capabilities {
     public static final CapableOf REPORTING = new CapableOf(true, false);
     public static final CapableOf REPORTING_TAGGING = new CapableOf(true, true);
 
-    private boolean reporting;
-    private boolean tagging;
+    private final boolean reporting;
+    private final boolean tagging;
 
     public CapableOf(boolean reporting, boolean tagging) {
         this.reporting = reporting;
@@ -69,8 +69,8 @@ public class CapableOf implements Capabilities {
     public int hashCode() {
         int code = 0;
 
-        code = 31 * code + new Boolean(reporting).hashCode();
-        code = 31 * code + new Boolean(tagging).hashCode();
+        code = 31 * code + Boolean.valueOf(reporting).hashCode();
+        code = 31 * code + Boolean.valueOf(tagging).hashCode();
 
         return code;
     }

--- a/core/src/main/java/com/uber/m3/tally/CounterImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/CounterImpl.java
@@ -28,8 +28,8 @@ import java.util.concurrent.atomic.AtomicLong;
  * Default implementation of a {@link Counter}.
  */
 class CounterImpl implements Counter {
-    private AtomicLong prev = new AtomicLong(0);
-    private AtomicLong curr = new AtomicLong(0);
+    private final AtomicLong prev = new AtomicLong(0);
+    private final AtomicLong curr = new AtomicLong(0);
 
     @Override
     public void inc(long delta) {

--- a/core/src/main/java/com/uber/m3/tally/CounterSnapshotImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/CounterSnapshotImpl.java
@@ -28,9 +28,9 @@ import java.util.Map;
  * Default implementation of a {@link CounterSnapshot}.
  */
 class CounterSnapshotImpl implements CounterSnapshot {
-    private String name;
-    private ImmutableMap<String, String> tags;
-    private long value;
+    private final String name;
+    private final ImmutableMap<String, String> tags;
+    private final long value;
 
     CounterSnapshotImpl(String name, ImmutableMap<String, String> tags, long value) {
         this.name = name;

--- a/core/src/main/java/com/uber/m3/tally/DurationBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/DurationBuckets.java
@@ -47,7 +47,7 @@ public class DurationBuckets extends AbstractBuckets<Duration> {
 
     @Override
     public Duration[] asDurations() {
-        return buckets.toArray(new Duration[buckets.size()]);
+        return buckets.toArray(new Duration[0]);
     }
 
     /**
@@ -106,7 +106,6 @@ public class DurationBuckets extends AbstractBuckets<Duration> {
 
     /**
      * Allows to create bucket with finer bucket creation control
-     *
      * @param sortedDurations sorted values (ascending) of upper bound of the buckets
      * @return {@link DurationBuckets} of the specified parameters
      */

--- a/core/src/main/java/com/uber/m3/tally/GaugeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/GaugeImpl.java
@@ -29,8 +29,8 @@ import java.util.concurrent.atomic.AtomicLong;
  * Default implementation of a {@link Gauge}.
  */
 class GaugeImpl implements Gauge {
-    private AtomicBoolean updated = new AtomicBoolean(false);
-    private AtomicLong curr = new AtomicLong(0);
+    private final AtomicBoolean updated = new AtomicBoolean(false);
+    private final AtomicLong curr = new AtomicLong(0);
 
     @Override
     public void update(double value) {

--- a/core/src/main/java/com/uber/m3/tally/GaugeSnapshotImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/GaugeSnapshotImpl.java
@@ -28,9 +28,9 @@ import java.util.Map;
  * Default implementation of a {@link GaugeSnapshot}.
  */
 class GaugeSnapshotImpl implements GaugeSnapshot {
-    private String name;
-    private ImmutableMap<String, String> tags;
-    private double value;
+    private final String name;
+    private final ImmutableMap<String, String> tags;
+    private final double value;
 
     GaugeSnapshotImpl(String name, ImmutableMap<String, String> tags, double value) {
         this.name = name;

--- a/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
@@ -33,13 +33,13 @@ import java.util.Map;
  * Default implementation of a {@link Histogram}.
  */
 class HistogramImpl implements Histogram, StopwatchRecorder {
-    private Type type;
-    private String name;
-    private ImmutableMap<String, String> tags;
-    private Buckets specification;
-    private List<HistogramBucket> buckets;
-    private List<Double> lookupByValue;
-    private List<Duration> lookupByDuration;
+    private final Type type;
+    private final String name;
+    private final ImmutableMap<String, String> tags;
+    private final Buckets specification;
+    private final List<HistogramBucket> buckets;
+    private final List<Double> lookupByValue;
+    private final List<Duration> lookupByDuration;
 
     HistogramImpl(
         String name,
@@ -186,7 +186,7 @@ class HistogramImpl implements Histogram, StopwatchRecorder {
         recordDuration(Duration.between(stopwatchStart, System.nanoTime()));
     }
 
-    class HistogramBucket {
+    static class HistogramBucket {
         CounterImpl samples;
         double valueLowerBound;
         double valueUpperBound;

--- a/core/src/main/java/com/uber/m3/tally/HistogramSnapshotImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/HistogramSnapshotImpl.java
@@ -29,10 +29,10 @@ import java.util.Map;
  * Default implementation of a {@link HistogramSnapshot}.
  */
 class HistogramSnapshotImpl implements HistogramSnapshot {
-    private String name;
-    private ImmutableMap<String, String> tags;
-    private Map<Double, Long> values;
-    private Map<Duration, Long> durations;
+    private final String name;
+    private final ImmutableMap<String, String> tags;
+    private final Map<Double, Long> values;
+    private final Map<Duration, Long> durations;
 
     HistogramSnapshotImpl(
         String name,

--- a/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
@@ -33,14 +33,14 @@ import java.util.concurrent.ScheduledExecutorService;
  * Default {@link Scope} implementation.
  */
 class ScopeImpl implements Scope {
-    private StatsReporter reporter;
-    private String prefix;
-    private String separator;
-    private ImmutableMap<String, String> tags;
-    private Buckets defaultBuckets;
+    private final StatsReporter reporter;
+    private final String prefix;
+    private final String separator;
+    private final ImmutableMap<String, String> tags;
+    private final Buckets defaultBuckets;
 
-    private ScheduledExecutorService scheduler;
-    private Registry registry;
+    private final ScheduledExecutorService scheduler;
+    private final Registry registry;
 
     // ConcurrentHashMap nearly always allowing read operations seems like a good
     // performance upside to the consequence of reporting a newly-made metric in
@@ -71,15 +71,8 @@ class ScopeImpl implements Scope {
             return counter;
         }
 
-        synchronized (counters) {
-            if (!counters.containsKey(name)) {
-                counters.put(name, new CounterImpl());
-            }
-
-            counter = counters.get(name);
-        }
-
-        return counter;
+        counters.putIfAbsent(name, new CounterImpl());
+        return counters.get(name);
     }
 
     @Override
@@ -90,15 +83,8 @@ class ScopeImpl implements Scope {
             return gauge;
         }
 
-        synchronized (gauges) {
-            if (!gauges.containsKey(name)) {
-                gauges.put(name, new GaugeImpl());
-            }
-
-            gauge = gauges.get(name);
-        }
-
-        return gauge;
+        gauges.putIfAbsent(name, new GaugeImpl());
+        return gauges.get(name);
     }
 
     @Override
@@ -109,15 +95,8 @@ class ScopeImpl implements Scope {
             return timer;
         }
 
-        synchronized (timers) {
-            if (!timers.containsKey(name)) {
-                timers.put(name, new TimerImpl(fullyQualifiedName(name), tags, reporter));
-            }
-
-            timer = timers.get(name);
-        }
-
-        return timer;
+        timers.putIfAbsent(name, new TimerImpl(fullyQualifiedName(name), tags, reporter));
+        return timers.get(name);
     }
 
     @Override
@@ -132,15 +111,8 @@ class ScopeImpl implements Scope {
             return histogram;
         }
 
-        synchronized (histograms) {
-            if (!histograms.containsKey(name)) {
-                histograms.put(name, new HistogramImpl(fullyQualifiedName(name), tags, reporter, buckets));
-            }
-
-            histogram = histograms.get(name);
-        }
-
-        return histogram;
+        histograms.putIfAbsent(name, new HistogramImpl(fullyQualifiedName(name), tags, reporter, buckets));
+        return histograms.get(name);
     }
 
     @Override
@@ -208,11 +180,11 @@ class ScopeImpl implements Scope {
         }
 
         if (stringMap == null) {
-            stringMap = ImmutableMap.EMPTY;
+            stringMap = (ImmutableMap<String, String>) ImmutableMap.EMPTY;
         }
 
         Set<String> keySet = stringMap.keySet();
-        String[] sortedKeys = keySet.toArray(new String[keySet.size()]);
+        String[] sortedKeys = keySet.toArray(new String[0]);
         Arrays.sort(sortedKeys);
 
         StringBuilder keyBuffer = new StringBuilder(prefix.length() + sortedKeys.length * 20);

--- a/core/src/main/java/com/uber/m3/tally/SnapshotImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/SnapshotImpl.java
@@ -27,10 +27,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * Default implementation of a {@link Snapshot}.
  */
 class SnapshotImpl implements Snapshot {
-    Map<String, CounterSnapshot> counters = new ConcurrentHashMap<>();
-    Map<String, GaugeSnapshot> gauges = new ConcurrentHashMap<>();
-    Map<String, TimerSnapshot> timers = new ConcurrentHashMap<>();
-    Map<String, HistogramSnapshot> histograms = new ConcurrentHashMap<>();
+    private final Map<String, CounterSnapshot> counters = new ConcurrentHashMap<>();
+    private final Map<String, GaugeSnapshot> gauges = new ConcurrentHashMap<>();
+    private final Map<String, TimerSnapshot> timers = new ConcurrentHashMap<>();
+    private final Map<String, HistogramSnapshot> histograms = new ConcurrentHashMap<>();
 
     @Override
     public Map<String, CounterSnapshot> counters() {

--- a/core/src/main/java/com/uber/m3/tally/StatsReporter.java
+++ b/core/src/main/java/com/uber/m3/tally/StatsReporter.java
@@ -35,9 +35,9 @@ public interface StatsReporter extends BaseStatsReporter {
      * @param value value to report
      */
     void reportCounter(
-            String name,
-            Map<String, String> tags,
-            long value
+        String name,
+        Map<String, String> tags,
+        long value
     );
 
     /**
@@ -47,9 +47,9 @@ public interface StatsReporter extends BaseStatsReporter {
      * @param value value to report
      */
     void reportGauge(
-            String name,
-            Map<String, String> tags,
-            double value
+        String name,
+        Map<String, String> tags,
+        double value
     );
 
     /**
@@ -59,9 +59,9 @@ public interface StatsReporter extends BaseStatsReporter {
      * @param interval interval to report
      */
     void reportTimer(
-            String name,
-            Map<String, String> tags,
-            Duration interval
+        String name,
+        Map<String, String> tags,
+        Duration interval
     );
 
     /**
@@ -74,12 +74,12 @@ public interface StatsReporter extends BaseStatsReporter {
      * @param samples          samples to report
      */
     void reportHistogramValueSamples(
-            String name,
-            Map<String, String> tags,
-            Buckets buckets,
-            double bucketLowerBound,
-            double bucketUpperBound,
-            long samples
+        String name,
+        Map<String, String> tags,
+        Buckets buckets,
+        double bucketLowerBound,
+        double bucketUpperBound,
+        long samples
     );
 
     /**
@@ -92,11 +92,11 @@ public interface StatsReporter extends BaseStatsReporter {
      * @param samples          samples to report
      */
     void reportHistogramDurationSamples(
-            String name,
-            Map<String, String> tags,
-            Buckets buckets,
-            Duration bucketLowerBound,
-            Duration bucketUpperBound,
-            long samples
+        String name,
+        Map<String, String> tags,
+        Buckets buckets,
+        Duration bucketLowerBound,
+        Duration bucketUpperBound,
+        long samples
     );
 }

--- a/core/src/main/java/com/uber/m3/tally/Stopwatch.java
+++ b/core/src/main/java/com/uber/m3/tally/Stopwatch.java
@@ -27,8 +27,8 @@ package com.uber.m3.tally;
  * of the stopwatch are comparable with one another.
  */
 public class Stopwatch {
-    private long startNanos;
-    private StopwatchRecorder recorder;
+    private final long startNanos;
+    private final StopwatchRecorder recorder;
 
     /**
      * Creates a stopwatch.

--- a/core/src/main/java/com/uber/m3/tally/TimerImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/TimerImpl.java
@@ -34,10 +34,10 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Default implementation of a {@link Timer}.
  */
 class TimerImpl implements Timer, StopwatchRecorder {
-    private String name;
-    private ImmutableMap<String, String> tags;
-    private StatsReporter reporter;
-    private Values unreported = new Values();
+    private final String name;
+    private final ImmutableMap<String, String> tags;
+    private final StatsReporter reporter;
+    private final Values unreported = new Values();
 
     TimerImpl(String name, ImmutableMap<String, String> tags, StatsReporter reporter) {
         this.name = name;
@@ -89,7 +89,7 @@ class TimerImpl implements Timer, StopwatchRecorder {
         // instead as this separation is not needed e.g. we only lock a
         // ConcurrentHashMap when doing writes and not for reads.
         private final ReadWriteLock rwlock = new ReentrantReadWriteLock();
-        private List<Duration> values = new ArrayList<>();
+        private final List<Duration> values = new ArrayList<>();
 
         Lock readLock() {
             return rwlock.readLock();

--- a/core/src/main/java/com/uber/m3/tally/TimerSnapshotImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/TimerSnapshotImpl.java
@@ -29,9 +29,9 @@ import java.util.Map;
  * Default implementation of a {@link TimerSnapshot}.
  */
 class TimerSnapshotImpl implements TimerSnapshot {
-    private String name;
-    private ImmutableMap<String, String> tags;
-    private Duration[] values;
+    private final String name;
+    private final ImmutableMap<String, String> tags;
+    private final Duration[] values;
 
     TimerSnapshotImpl(String name, ImmutableMap<String, String> tags, Duration[] values) {
         this.name = name;

--- a/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
@@ -36,7 +36,7 @@ public class ValueBuckets extends AbstractBuckets<Double> {
 
     @Override
     public Double[] asValues() {
-        return buckets.toArray(new Double[buckets.size()]);
+        return buckets.toArray(new Double[0]);
     }
 
     @Override
@@ -93,7 +93,7 @@ public class ValueBuckets extends AbstractBuckets<Double> {
 
         Double[] buckets = new Double[numBuckets];
 
-        Double curDuration = start;
+        double curDuration = start;
 
         for (int i = 0; i < numBuckets; i++) {
             buckets[i] = curDuration;
@@ -106,7 +106,6 @@ public class ValueBuckets extends AbstractBuckets<Double> {
 
     /**
      * Helper function to create {@link ValueBuckets} with custom buckets.
-     *
      * @param sortedBucketUpperValues sorted (ascending order) values of bucket's upper bound
      * @return {@link ValueBuckets} of the specified paramters
      */

--- a/core/src/main/java/com/uber/m3/util/ImmutableList.java
+++ b/core/src/main/java/com/uber/m3/util/ImmutableList.java
@@ -32,7 +32,7 @@ public class ImmutableList<E> implements List<E> {
     private final ArrayList<E> collection;
 
     public ImmutableList(Collection<E> collection) {
-        this.collection = new ArrayList(collection);
+        this.collection = new ArrayList<>(collection);
     }
 
     @Override
@@ -162,7 +162,7 @@ public class ImmutableList<E> implements List<E> {
             return false;
         }
 
-        return collection.equals(((ImmutableList) other).collection);
+        return collection.equals(((ImmutableList<?>) other).collection);
     }
 
     @Override

--- a/core/src/main/java/com/uber/m3/util/ImmutableMap.java
+++ b/core/src/main/java/com/uber/m3/util/ImmutableMap.java
@@ -29,7 +29,7 @@ import java.util.Map;
  * @param <V> the value type
  */
 public class ImmutableMap<K, V> implements Map<K, V> {
-    public static final ImmutableMap EMPTY = new ImmutableMap();
+    public static final ImmutableMap<?, ?> EMPTY = new ImmutableMap<>();
 
     private final HashMap<K, V> map;
 
@@ -183,7 +183,7 @@ public class ImmutableMap<K, V> implements Map<K, V> {
             return false;
         }
 
-        return map.equals(((ImmutableMap) other).map);
+        return map.equals(((ImmutableMap<?, ?>) other).map);
     }
 
     @Override
@@ -202,7 +202,7 @@ public class ImmutableMap<K, V> implements Map<K, V> {
      * @param <V> the value type
      */
     public static class Builder<K, V> {
-        private HashMap<K, V> map;
+        private final HashMap<K, V> map;
 
         public Builder() {
             this(16, 0.75f);

--- a/core/src/main/java/com/uber/m3/util/ImmutableSet.java
+++ b/core/src/main/java/com/uber/m3/util/ImmutableSet.java
@@ -112,7 +112,7 @@ public class ImmutableSet<E> implements Set<E> {
             return false;
         }
 
-        return set.equals(((ImmutableSet) other).set);
+        return set.equals(((ImmutableSet<?>) other).set);
     }
 
     @Override
@@ -125,7 +125,7 @@ public class ImmutableSet<E> implements Set<E> {
      * @param <E> the type of elements in this set
      */
     public static class Builder<E> {
-        private HashSet<E> set;
+        private final HashSet<E> set;
 
         public Builder() {
             this(16, 0.75f);

--- a/core/src/main/java/com/uber/m3/util/UnmodifiableIterator.java
+++ b/core/src/main/java/com/uber/m3/util/UnmodifiableIterator.java
@@ -26,11 +26,11 @@ import java.util.Iterator;
  * A thin wrapper around an {@code Iterator} to disallow modifications to this
  * iterator.
  * <p>
- *     <strong>Note:</strong> Take care in using this class. If the user has a
- *     reference to constructing iterator, this iterator can still be modified
- *     from under the hood. This class mainly serves as an iterator over
- *     {@code Immutable*} classes, where users will not have a reference to the underlying
- *     iterator.
+ * <strong>Note:</strong> Take care in using this class. If the user has a
+ * reference to constructing iterator, this iterator can still be modified
+ * from under the hood. This class mainly serves as an iterator over
+ * {@code Immutable*} classes, where users will not have a reference to the underlying
+ * iterator.
  * </p>
  * @param <E> the type of element this iterator iterates over
  */

--- a/core/src/main/java/com/uber/m3/util/UnmodifiableListIterator.java
+++ b/core/src/main/java/com/uber/m3/util/UnmodifiableListIterator.java
@@ -26,11 +26,11 @@ import java.util.ListIterator;
  * A thin wrapper around a {@code ListIterator} to disallow modifications to this
  * list iterator.
  * <p>
- *     <strong>Note:</strong> Take care in using this class. If the user has a
- *     reference to constructing iterator, this iterator can still be modified
- *     from under the hood. This class mainly serves as an iterator over
- *     {@code Immutable*} classes, where users will not have a reference to the underlying
- *     iterator.
+ * <strong>Note:</strong> Take care in using this class. If the user has a
+ * reference to constructing iterator, this iterator can still be modified
+ * from under the hood. This class mainly serves as an iterator over
+ * {@code Immutable*} classes, where users will not have a reference to the underlying
+ * iterator.
  * </p>
  * @param <E> the type of element this iterator iterates over
  */

--- a/core/src/test/java/com/uber/m3/tally/BucketPairImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/BucketPairImplTest.java
@@ -25,8 +25,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
 
 public class BucketPairImplTest {
     @Test
@@ -97,11 +96,11 @@ public class BucketPairImplTest {
         BucketPair bucketPair = BucketPairImpl.bucketPairs(null)[0];
         BucketPair sameBucketPair = BucketPairImpl.bucketPairs(null)[0];
 
-        assertTrue(bucketPair.equals(sameBucketPair));
-        assertTrue(bucketPair.equals(bucketPair));
+        assertEquals(bucketPair, sameBucketPair);
+        assertEquals(bucketPair, bucketPair);
         assertEquals(bucketPair.hashCode(), sameBucketPair.hashCode());
 
-        assertFalse(bucketPair.equals(null));
-        assertFalse(bucketPair.equals(9));
+        assertNotEquals(null, bucketPair);
+        assertNotEquals(9, bucketPair);
     }
 }

--- a/core/src/test/java/com/uber/m3/tally/CapableOfTest.java
+++ b/core/src/test/java/com/uber/m3/tally/CapableOfTest.java
@@ -20,15 +20,16 @@
 
 package com.uber.m3.tally;
 
+import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
 
 public class CapableOfTest {
     @Test
-    public void capabilities() throws Exception {
+    public void capabilities() {
         Capabilities capabilities = new CapableOf(false, true);
 
         assertFalse(capabilities.reporting());
@@ -45,16 +46,16 @@ public class CapableOfTest {
     }
 
     @Test
-    public void equalsHashCode() throws Exception {
-        assertFalse(CapableOf.NONE.equals(null));
-        assertFalse(CapableOf.NONE.equals(9));
+    public void equalsHashCode() {
+        assertNotEquals(null, CapableOf.NONE);
+        assertNotEquals(9, CapableOf.NONE);
 
-        assertFalse(CapableOf.NONE.equals(CapableOf.REPORTING));
-        assertFalse(new CapableOf(true, false).equals(new CapableOf(false, true)));
+        assertNotEquals(CapableOf.NONE, CapableOf.REPORTING);
+        assertNotEquals(new CapableOf(true, false), new CapableOf(false, true));
 
-        assertTrue(CapableOf.REPORTING.equals(CapableOf.REPORTING));
-        assertTrue(CapableOf.REPORTING.equals(new CapableOf(true, false)));
+        assertEquals(CapableOf.REPORTING, CapableOf.REPORTING);
+        assertEquals(CapableOf.REPORTING, new CapableOf(true, false));
         assertEquals(CapableOf.REPORTING.hashCode(), new CapableOf(true, false).hashCode());
-        assertTrue(new CapableOf(false, false).equals(new CapableOf(false, false)));
+        assertEquals(new CapableOf(false, false), new CapableOf(false, false));
     }
 }

--- a/core/src/test/java/com/uber/m3/tally/DurationBucketsTest.java
+++ b/core/src/test/java/com/uber/m3/tally/DurationBucketsTest.java
@@ -20,21 +20,21 @@
 
 package com.uber.m3.tally;
 
+import com.uber.m3.util.Duration;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
-import org.hamcrest.CoreMatchers;
-import org.junit.Test;
-
-import com.uber.m3.util.Duration;
-
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class DurationBucketsTest {
     @Test
@@ -44,7 +44,7 @@ public class DurationBucketsTest {
         assertFalse(buckets.isEmpty());
         assertTrue(buckets.contains(Duration.ofMillis(120)));
 
-        for (Iterator iter : new Iterator[]{buckets.iterator(), buckets.listIterator()}) {
+        for (Iterator<?> iter : new Iterator[]{buckets.iterator(), buckets.listIterator()}) {
             for (int i = 0; i < buckets.size(); i++) {
                 assertEquals(Duration.ofMillis(100 + 10 * i), iter.next());
             }
@@ -135,7 +135,7 @@ public class DurationBucketsTest {
             Duration.ofNanos(1000)
         });
 
-        Double[] expectedBuckets = new Double[] {
+        Double[] expectedBuckets = new Double[]{
             10d / Duration.NANOS_PER_SECOND,
             30d / Duration.NANOS_PER_SECOND,
             55d / Duration.NANOS_PER_SECOND,
@@ -209,26 +209,26 @@ public class DurationBucketsTest {
     @Test
     public void custom() {
         DurationBuckets expectedBuckets = new DurationBuckets(
-                new Duration[] {
-                        Duration.ofMillis(1),
-                        Duration.ofMillis(2),
-                        Duration.ofMillis(3),
-                        Duration.ofMillis(5),
-                        Duration.ofMillis(7),
-                        Duration.ofMillis(10),
-                }
+            new Duration[]{
+                Duration.ofMillis(1),
+                Duration.ofMillis(2),
+                Duration.ofMillis(3),
+                Duration.ofMillis(5),
+                Duration.ofMillis(7),
+                Duration.ofMillis(10),
+            }
         );
 
         assertThat("custom buckets are created as per our expectations",
-                DurationBuckets.custom(
-                        Duration.ofMillis(1),
-                        Duration.ofMillis(2),
-                        Duration.ofMillis(3),
-                        Duration.ofMillis(5),
-                        Duration.ofMillis(7),
-                        Duration.ofMillis(10)
-                ),
-                CoreMatchers.equalTo(expectedBuckets));
+            DurationBuckets.custom(
+                Duration.ofMillis(1),
+                Duration.ofMillis(2),
+                Duration.ofMillis(3),
+                Duration.ofMillis(5),
+                Duration.ofMillis(7),
+                Duration.ofMillis(10)
+            ),
+            CoreMatchers.equalTo(expectedBuckets));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -239,9 +239,9 @@ public class DurationBucketsTest {
     @Test(expected = IllegalArgumentException.class)
     public void customFailWithUnsortedBuckets() {
         DurationBuckets.custom(
-                Duration.ofMillis(1),
-                Duration.ofMillis(3),
-                Duration.ofMillis(2)
+            Duration.ofMillis(1),
+            Duration.ofMillis(3),
+            Duration.ofMillis(2)
         );
     }
 
@@ -262,10 +262,10 @@ public class DurationBucketsTest {
         DurationBuckets buckets = DurationBuckets.linear(Duration.ZERO, Duration.ofSeconds(10), 3);
         DurationBuckets sameBuckets = DurationBuckets.linear(Duration.ZERO, Duration.ofSeconds(10), 3);
 
-        assertTrue(buckets.equals(sameBuckets));
+        assertEquals(buckets, sameBuckets);
         assertEquals(buckets.hashCode(), sameBuckets.hashCode());
 
-        assertFalse(buckets.equals(null));
-        assertFalse(buckets.equals(9));
+        assertNotEquals(null, buckets);
+        assertNotEquals(9, buckets);
     }
 }

--- a/core/src/test/java/com/uber/m3/tally/NoopScopeTest.java
+++ b/core/src/test/java/com/uber/m3/tally/NoopScopeTest.java
@@ -20,12 +20,12 @@
 
 package com.uber.m3.tally;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class NoopScopeTest {
 
@@ -35,14 +35,14 @@ public class NoopScopeTest {
         Counter noopCounter1 = noopScope.counter("test1");
         Counter noopCounter2 = noopScope.counter("test2");
         Assert.assertThat(
-                "same noop counter returned",
-                noopCounter1 == noopCounter2,
-                CoreMatchers.equalTo(true)
+            "same noop counter returned",
+            noopCounter1 == noopCounter2,
+            CoreMatchers.equalTo(true)
         );
         Assert.assertThat(
-                "noop counter",
-                noopCounter1 == NoopScope.NOOP_COUNTER,
-                CoreMatchers.equalTo(true)
+            "noop counter",
+            noopCounter1 == NoopScope.NOOP_COUNTER,
+            CoreMatchers.equalTo(true)
         );
     }
 
@@ -52,14 +52,14 @@ public class NoopScopeTest {
         Gauge noopGauge1 = noopScope.gauge("test1");
         Gauge noopGauge2 = noopScope.gauge("test2");
         Assert.assertThat(
-                "same noop gauge returned",
-                noopGauge1 == noopGauge2,
-                CoreMatchers.equalTo(true)
+            "same noop gauge returned",
+            noopGauge1 == noopGauge2,
+            CoreMatchers.equalTo(true)
         );
         Assert.assertThat(
-                "noop gauge",
-                noopGauge1 == NoopScope.NOOP_GAUGE,
-                CoreMatchers.equalTo(true)
+            "noop gauge",
+            noopGauge1 == NoopScope.NOOP_GAUGE,
+            CoreMatchers.equalTo(true)
         );
     }
 
@@ -69,19 +69,19 @@ public class NoopScopeTest {
         Timer noopTimer1 = noopScope.timer("test1");
         Timer noopTimer2 = noopScope.timer("test2");
         Assert.assertThat(
-                "same noop timer returned",
-                noopTimer1 == noopTimer2,
-                CoreMatchers.equalTo(true)
+            "same noop timer returned",
+            noopTimer1 == noopTimer2,
+            CoreMatchers.equalTo(true)
         );
         Assert.assertThat(
-                "noop timer",
-                noopTimer1 == NoopScope.NOOP_TIMER,
-                CoreMatchers.equalTo(true)
+            "noop timer",
+            noopTimer1 == NoopScope.NOOP_TIMER,
+            CoreMatchers.equalTo(true)
         );
         Assert.assertThat(
-                "noop stopwatch",
-                noopTimer1.start() == NoopScope.NOOP_STOPWATCH,
-                CoreMatchers.equalTo(true)
+            "noop stopwatch",
+            noopTimer1.start() == NoopScope.NOOP_STOPWATCH,
+            CoreMatchers.equalTo(true)
         );
     }
 
@@ -92,14 +92,14 @@ public class NoopScopeTest {
         Histogram noopHistogram2 = noopScope.histogram("test2", ValueBuckets.custom(4, 5, 6));
 
         Assert.assertThat(
-                "same noop histogram returned",
-                noopHistogram1 == noopHistogram2,
-                CoreMatchers.equalTo(true)
+            "same noop histogram returned",
+            noopHistogram1 == noopHistogram2,
+            CoreMatchers.equalTo(true)
         );
         Assert.assertThat(
-                "noop histogram",
-                noopHistogram1 == NoopScope.NOOP_HISTOGRAM,
-                CoreMatchers.equalTo(true)
+            "noop histogram",
+            noopHistogram1 == NoopScope.NOOP_HISTOGRAM,
+            CoreMatchers.equalTo(true)
         );
     }
 
@@ -109,14 +109,14 @@ public class NoopScopeTest {
         Capabilities noopCapabilities1 = noopScope.capabilities();
         Capabilities noopCapabilities2 = noopScope.capabilities();
         Assert.assertThat(
-                "same noop capabilities returned",
-                noopCapabilities1 == noopCapabilities2,
-                CoreMatchers.equalTo(true)
+            "same noop capabilities returned",
+            noopCapabilities1 == noopCapabilities2,
+            CoreMatchers.equalTo(true)
         );
         Assert.assertThat(
-                "noop capabilities",
-                noopCapabilities1 == NoopScope.NOOP_CAPABILITIES,
-                CoreMatchers.equalTo(true)
+            "noop capabilities",
+            noopCapabilities1 == NoopScope.NOOP_CAPABILITIES,
+            CoreMatchers.equalTo(true)
         );
     }
 
@@ -126,12 +126,12 @@ public class NoopScopeTest {
         Scope noopScope1 = noopScope.subScope("test1");
         Scope noopScope2 = noopScope.subScope("test2");
         Assert.assertThat("same noop scope returned",
-                noopScope1 == noopScope2,
-                CoreMatchers.equalTo(true)
+            noopScope1 == noopScope2,
+            CoreMatchers.equalTo(true)
         );
         Assert.assertThat("noop scope returned",
-                noopScope1 == noopScope,
-                CoreMatchers.equalTo(true)
+            noopScope1 == noopScope,
+            CoreMatchers.equalTo(true)
         );
     }
 
@@ -149,12 +149,12 @@ public class NoopScopeTest {
         Scope noopScope1 = noopScope.tagged(tagMap1);
         Scope noopScope2 = noopScope.tagged(tagMap2);
         Assert.assertThat("same noop scope returned",
-                noopScope1 == noopScope2,
-                CoreMatchers.equalTo(true)
+            noopScope1 == noopScope2,
+            CoreMatchers.equalTo(true)
         );
         Assert.assertThat("noop scope returned",
-                noopScope1 == noopScope,
-                CoreMatchers.equalTo(true)
+            noopScope1 == noopScope,
+            CoreMatchers.equalTo(true)
         );
     }
 }

--- a/core/src/test/java/com/uber/m3/tally/ScopeImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/ScopeImplTest.java
@@ -20,19 +20,18 @@
 
 package com.uber.m3.tally;
 
+import com.uber.m3.util.Duration;
+import com.uber.m3.util.ImmutableMap;
+import org.junit.Test;
+
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
-
-import com.uber.m3.util.Duration;
-import com.uber.m3.util.ImmutableMap;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 public class ScopeImplTest {
     private static final double EPSILON = 1e-10;
@@ -54,21 +53,21 @@ public class ScopeImplTest {
 
         Counter sameCounter = scope.counter("new-counter");
         // Should be the same Counter object and not a new instance
-        assertTrue(counter == sameCounter);
+        assertEquals(counter, sameCounter);
 
         Gauge gauge = scope.gauge("new-gauge");
         assertNotNull(gauge);
 
         Gauge sameGauge = scope.gauge("new-gauge");
         // Should be the same Gauge object and not a new instance
-        assertTrue(gauge == sameGauge);
+        assertEquals(gauge, sameGauge);
 
         Timer timer = scope.timer("new-timer");
         assertNotNull(timer);
 
         Timer sameTimer = scope.timer("new-timer");
         // Should be the same Timer object and not a new instance
-        assertTrue(timer == sameTimer);
+        assertEquals(timer, sameTimer);
 
         Histogram histogram = scope.histogram(
             "new-histogram",
@@ -78,7 +77,7 @@ public class ScopeImplTest {
 
         Histogram sameHistogram = scope.histogram("new-histogram", null);
         // Should be the same Histogram object and not a new instance
-        assertTrue(histogram == sameHistogram);
+        assertEquals(histogram, sameHistogram);
     }
 
     @Test
@@ -151,9 +150,9 @@ public class ScopeImplTest {
 
         ImmutableMap<String, String> additionalTags =
             new ImmutableMap.Builder<String, String>(2)
-            .put("new_key", "new_val")
-            .put("baz", "quz")
-            .build();
+                .put("new_key", "new_val")
+                .put("baz", "quz")
+                .build();
         Scope taggedSubscope = rootScope.tagged(additionalTags);
         Timer taggedTimer = taggedSubscope.timer("tagged_timer");
         taggedTimer.record(Duration.ofSeconds(6));
@@ -180,9 +179,9 @@ public class ScopeImplTest {
         assertEquals("tagged_timer", timer.getName());
         ImmutableMap<String, String> expectedTags =
             new ImmutableMap.Builder<String, String>(4)
-            .putAll(tags)
-            .putAll(additionalTags)
-            .build();
+                .putAll(tags)
+                .putAll(additionalTags)
+                .build();
         assertEquals(expectedTags, timer.getTags());
     }
 
@@ -222,24 +221,24 @@ public class ScopeImplTest {
         Map<String, CounterSnapshot> counters = snapshot.counters();
         assertEquals(1, counters.size());
         assertEquals("snapshot-counter", counters.get("snapshot-counter+").name());
-        assertEquals(null, counters.get("snapshot-counter+").tags());
+        assertNull(counters.get("snapshot-counter+").tags());
 
         Map<String, GaugeSnapshot> gauges = snapshot.gauges();
         assertEquals(3, gauges.size());
         assertEquals("snapshot-gauge", gauges.get("snapshot-gauge+").name());
-        assertEquals(null, gauges.get("snapshot-gauge+").tags());
+        assertNull(gauges.get("snapshot-gauge+").tags());
         assertEquals(120, gauges.get("snapshot-gauge+").value(), EPSILON);
         assertEquals("snapshot-gauge2", gauges.get("snapshot-gauge2+").name());
-        assertEquals(null, gauges.get("snapshot-gauge2+").tags());
+        assertNull(gauges.get("snapshot-gauge2+").tags());
         assertEquals(220, gauges.get("snapshot-gauge2+").value(), EPSILON);
         assertEquals("snapshot-gauge3", gauges.get("snapshot-gauge3+").name());
-        assertEquals(null, gauges.get("snapshot-gauge3+").tags());
+        assertNull(gauges.get("snapshot-gauge3+").tags());
         assertEquals(320, gauges.get("snapshot-gauge3+").value(), EPSILON);
 
         Map<String, TimerSnapshot> timers = snapshot.timers();
         assertEquals(1, timers.size());
         assertEquals("snapshot-timer", timers.get("snapshot-timer+").name());
-        assertEquals(null, timers.get("snapshot-timer+").tags());
+        assertNull(timers.get("snapshot-timer+").tags());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -251,19 +250,12 @@ public class ScopeImplTest {
     public void exceptionInReportLoop() throws ScopeCloseException, InterruptedException {
         final AtomicInteger uncaghtExceptionReported = new AtomicInteger();
         ThrowingStatsReporter reporter = new ThrowingStatsReporter();
-        final UncaughtExceptionHandler uncaughtExceptionHandler = new UncaughtExceptionHandler() {
-            @Override
-            public void uncaughtException(Thread t, Throwable e) {
-                uncaghtExceptionReported.incrementAndGet();
-            }
-        };
+        final UncaughtExceptionHandler uncaughtExceptionHandler = (t, e) -> uncaghtExceptionReported.incrementAndGet();
 
-        Scope scope = new RootScopeBuilder()
+        try (Scope scope = new RootScopeBuilder()
             .reporter(reporter)
             .reportEvery(Duration.ofMillis(REPORT_INTERVAL_MILLIS),
-                uncaughtExceptionHandler);
-
-        try {
+                uncaughtExceptionHandler)) {
             scope.counter("hi").inc(1);
             Thread.sleep(SLEEP_MILLIS);
 
@@ -276,15 +268,13 @@ public class ScopeImplTest {
 
             assertEquals(2, uncaghtExceptionReported.get());
             assertEquals(2, reporter.getNumberOfReportedMetrics());
-        } finally {
-            scope.close();
         }
     }
 
     private static class ThrowingStatsReporter implements StatsReporter {
         private final AtomicInteger reported = new AtomicInteger();
 
-        public int getNumberOfReportedMetrics() {
+        int getNumberOfReportedMetrics() {
             return reported.get();
         }
 

--- a/core/src/test/java/com/uber/m3/tally/TestStatsReporter.java
+++ b/core/src/test/java/com/uber/m3/tally/TestStatsReporter.java
@@ -28,12 +28,12 @@ import java.util.Queue;
 import java.util.concurrent.LinkedBlockingDeque;
 
 public class TestStatsReporter implements StatsReporter {
-    private Queue<MetricStruct<Long>> counters = new LinkedBlockingDeque<>();
-    private Queue<MetricStruct<Double>> gauges = new LinkedBlockingDeque<>();
-    private Queue<MetricStruct<Duration>> timers = new LinkedBlockingDeque<>();
+    private final Queue<MetricStruct<Long>> counters = new LinkedBlockingDeque<>();
+    private final Queue<MetricStruct<Double>> gauges = new LinkedBlockingDeque<>();
+    private final Queue<MetricStruct<Duration>> timers = new LinkedBlockingDeque<>();
     private Buckets buckets;
-    private Map<Double, Long> valueSamples = new HashMap<>();
-    private Map<Duration, Long> durationSamples = new HashMap<>();
+    private final Map<Double, Long> valueSamples = new HashMap<>();
+    private final Map<Duration, Long> durationSamples = new HashMap<>();
 
     @Override
     public void reportCounter(String name, Map<String, String> tags, long value) {
@@ -127,9 +127,9 @@ public class TestStatsReporter implements StatsReporter {
     }
 
     static class MetricStruct<T> {
-        private String name;
-        private Map<String, String> tags;
-        private T value;
+        private final String name;
+        private final Map<String, String> tags;
+        private final T value;
 
         MetricStruct(String name, Map<String, String> tags, T value) {
             this.name = name;

--- a/core/src/test/java/com/uber/m3/tally/ValueBucketsTest.java
+++ b/core/src/test/java/com/uber/m3/tally/ValueBucketsTest.java
@@ -20,15 +20,13 @@
 
 package com.uber.m3.tally;
 
+import com.uber.m3.util.Duration;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
-import com.uber.m3.util.Duration;
-
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 
 public class ValueBucketsTest {
@@ -42,7 +40,7 @@ public class ValueBucketsTest {
             1000d
         });
 
-        Double[] expectedBuckets = new Double[] {
+        Double[] expectedBuckets = new Double[]{
             10d,
             30d,
             55d,
@@ -115,7 +113,7 @@ public class ValueBucketsTest {
 
     @Test
     public void custom() {
-        ValueBuckets expectedBuckets = new ValueBuckets(new Double[] {
+        ValueBuckets expectedBuckets = new ValueBuckets(new Double[]{
             1d,
             2d,
             3d,
@@ -123,8 +121,8 @@ public class ValueBucketsTest {
             7d
         });
         assertThat("Buckets are created as per our expectations",
-                ValueBuckets.custom(1D, 2D, 3D, 5D, 7D),
-                CoreMatchers.equalTo(expectedBuckets));
+            ValueBuckets.custom(1D, 2D, 3D, 5D, 7D),
+            CoreMatchers.equalTo(expectedBuckets));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -154,10 +152,10 @@ public class ValueBucketsTest {
         ValueBuckets buckets = ValueBuckets.linear(0, 10, 3);
         ValueBuckets sameBuckets = ValueBuckets.linear(0, 10, 3);
 
-        assertTrue(buckets.equals(sameBuckets));
+        assertEquals(buckets, sameBuckets);
         assertEquals(buckets.hashCode(), sameBuckets.hashCode());
 
-        assertFalse(buckets.equals(null));
-        assertFalse(buckets.equals(9));
+        assertNotEquals(null, buckets);
+        assertNotEquals(9, buckets);
     }
 }

--- a/core/src/test/java/com/uber/m3/util/DurationTest.java
+++ b/core/src/test/java/com/uber/m3/util/DurationTest.java
@@ -23,8 +23,7 @@ package com.uber.m3.util;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
 
 public class DurationTest {
     private static final double EPSILON = 1e-10;
@@ -102,15 +101,15 @@ public class DurationTest {
 
     @Test
     public void equals() {
-        assertTrue(Duration.ZERO.equals(Duration.ZERO));
-        assertTrue(Duration.ZERO.equals(Duration.ofNanos(0)));
-        assertTrue(Duration.ofMillis(6000).equals(Duration.ofSeconds(6)));
-        assertTrue(Duration.ofHours(1).equals(Duration.ofNanos(3_600_000_000_000L)));
+        assertEquals(Duration.ZERO, Duration.ZERO);
+        assertEquals(Duration.ZERO, Duration.ofNanos(0));
+        assertEquals(Duration.ofMillis(6000), Duration.ofSeconds(6));
+        assertEquals(Duration.ofHours(1), Duration.ofNanos(3_600_000_000_000L));
         assertEquals(Duration.ofHours(1).hashCode(), Duration.ofNanos(3_600_000_000_000L).hashCode());
 
-        assertFalse(Duration.ofMillis(6001).equals(Duration.ofSeconds(6)));
-        assertFalse(Duration.ZERO.equals(null));
-        assertFalse(Duration.ZERO.equals(1));
+        assertNotEquals(Duration.ofMillis(6001), Duration.ofSeconds(6));
+        assertNotEquals(null, Duration.ZERO);
+        assertNotEquals(1, Duration.ZERO);
     }
 
     @Test

--- a/core/src/test/java/com/uber/m3/util/ImmutableListTest.java
+++ b/core/src/test/java/com/uber/m3/util/ImmutableListTest.java
@@ -48,7 +48,7 @@ public class ImmutableListTest {
     public void size() {
         assertEquals(2, list.size());
 
-        list = new ImmutableList<>(new ArrayList<String>(0));
+        list = new ImmutableList<>(new ArrayList<>(0));
 
         assertEquals(0, list.size());
     }
@@ -57,7 +57,7 @@ public class ImmutableListTest {
     public void isEmpty() {
         assertFalse(list.isEmpty());
 
-        list = new ImmutableList<>(new ArrayList<String>(0));
+        list = new ImmutableList<>(new ArrayList<>(0));
 
         assertTrue(list.isEmpty());
     }
@@ -202,13 +202,13 @@ public class ImmutableListTest {
         helperList.add("zz");
         ImmutableList<String> differentList = new ImmutableList<>(helperList);
 
-        assertTrue(list.equals(sameList));
+        assertEquals(list, sameList);
         assertEquals(list.hashCode(), sameList.hashCode());
-        assertFalse(list.equals(differentList));
+        assertNotEquals(list, differentList);
         assertNotEquals(list.hashCode(), differentList.hashCode());
 
-        assertFalse(list.equals(null));
-        assertTrue(list.equals(list));
-        assertFalse(list.equals(1));
+        assertNotEquals(null, list);
+        assertEquals(list, list);
+        assertNotEquals(1, list);
     }
 }

--- a/core/src/test/java/com/uber/m3/util/ImmutableMapTest.java
+++ b/core/src/test/java/com/uber/m3/util/ImmutableMapTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class ImmutableMapTest {
@@ -66,18 +67,18 @@ public class ImmutableMapTest {
     public void size() {
         assertEquals(3, map.size());
 
-        map = new ImmutableMap<>(new HashMap<String, String>(0, 1));
+        map = new ImmutableMap<>(new HashMap<>(0, 1));
 
         assertEquals(0, map.size());
     }
 
     @Test
     public void isEmpty() {
-        assertEquals(false, map.isEmpty());
+        assertFalse(map.isEmpty());
 
-        map = new ImmutableMap<>(new HashMap<String, String>(0, 1));
+        map = new ImmutableMap<>(new HashMap<>(0, 1));
 
-        assertEquals(true, map.isEmpty());
+        assertTrue(map.isEmpty());
     }
 
     @Test
@@ -102,7 +103,7 @@ public class ImmutableMapTest {
     public void get() {
         assertEquals("val1", map.get("key1"));
 
-        assertEquals(null, map.get("key9"));
+        assertNull(map.get("key9"));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -145,27 +146,27 @@ public class ImmutableMapTest {
         ImmutableMap<String, String> sameMap = new ImmutableMap.Builder<String, String>()
             .putAll(helperMap).build();
 
-        assertTrue(map.equals(sameMap));
+        assertEquals(map, sameMap);
     }
 
     @Test
     public void equals() {
-        assertFalse(map.equals(null));
-        assertFalse(map.equals(1));
-        assertTrue(map.equals(map));
+        assertNotEquals(null, map);
+        assertNotEquals(1, map);
+        assertEquals(map, map);
 
         ImmutableMap<String, String> sameMap = new ImmutableMap<>(helperMap);
 
-        assertTrue(map.equals(sameMap));
+        assertEquals(map, sameMap);
         assertEquals(map.hashCode(), sameMap.hashCode());
 
         helperMap.put("key7", "val7");
         ImmutableMap<String, String> differentMap = new ImmutableMap<>(helperMap);
 
-        assertFalse(map.equals(differentMap));
+        assertNotEquals(map, differentMap);
         assertNotEquals(map.hashCode(), differentMap.hashCode());
 
-        assertTrue(ImmutableMap.EMPTY.equals(new ImmutableMap(new HashMap())));
+        assertEquals(ImmutableMap.EMPTY, new ImmutableMap<>(new HashMap<>()));
     }
 
     @Test

--- a/core/src/test/java/com/uber/m3/util/ImmutableSetTest.java
+++ b/core/src/test/java/com/uber/m3/util/ImmutableSetTest.java
@@ -50,7 +50,7 @@ public class ImmutableSetTest {
     public void size() {
         assertEquals(4, set.size());
 
-        set = new ImmutableSet<>(new HashSet<String>(0));
+        set = new ImmutableSet<>(new HashSet<>(0));
 
         assertEquals(0, set.size());
     }
@@ -59,7 +59,7 @@ public class ImmutableSetTest {
     public void isEmpty() {
         assertFalse(set.isEmpty());
 
-        set = new ImmutableSet<>(new HashSet<String>(0));
+        set = new ImmutableSet<>(new HashSet<>(0));
 
         assertTrue(set.isEmpty());
     }
@@ -119,7 +119,7 @@ public class ImmutableSetTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void addAll() {
-        set.addAll(new HashSet<String>());
+        set.addAll(new HashSet<>());
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -141,18 +141,18 @@ public class ImmutableSetTest {
     public void equals() {
         ImmutableSet<String> equalSet = new ImmutableSet<>(helperSet);
 
-        assertTrue(set.equals(equalSet));
+        assertEquals(set, equalSet);
         assertEquals(set.hashCode(), equalSet.hashCode());
 
         helperSet.add("zz");
         ImmutableSet<String> differentSet = new ImmutableSet<>(helperSet);
 
-        assertFalse(set.equals(differentSet));
+        assertNotEquals(set, differentSet);
         assertNotEquals(set.hashCode(), differentSet.hashCode());
 
-        assertFalse(set.equals(null));
-        assertTrue(set.equals(set));
-        assertFalse(set.equals(2));
+        assertNotEquals(null, set);
+        assertEquals(set, set);
+        assertNotEquals(2, set);
     }
 
     @Test

--- a/example/src/main/java/com/uber/m3/tally/example/PrintStatsReporter.java
+++ b/example/src/main/java/com/uber/m3/tally/example/PrintStatsReporter.java
@@ -23,8 +23,8 @@ package com.uber.m3.tally.example;
 import com.uber.m3.tally.Buckets;
 import com.uber.m3.tally.Capabilities;
 import com.uber.m3.tally.CapableOf;
-import com.uber.m3.util.Duration;
 import com.uber.m3.tally.StatsReporter;
+import com.uber.m3.util.Duration;
 
 import java.util.Map;
 

--- a/example/src/main/java/com/uber/m3/tally/example/PrintStatsReporterExample.java
+++ b/example/src/main/java/com/uber/m3/tally/example/PrintStatsReporterExample.java
@@ -21,13 +21,13 @@
 package com.uber.m3.tally.example;
 
 import com.uber.m3.tally.Counter;
-import com.uber.m3.tally.ScopeCloseException;
-import com.uber.m3.util.Duration;
 import com.uber.m3.tally.Gauge;
 import com.uber.m3.tally.RootScopeBuilder;
 import com.uber.m3.tally.Scope;
+import com.uber.m3.tally.ScopeCloseException;
 import com.uber.m3.tally.StatsReporter;
 import com.uber.m3.tally.Timer;
+import com.uber.m3.util.Duration;
 
 /**
  * PrintStatsReporterExample usage with a PrintStatsReporter reporting synthetically emitted metrics

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TCalcTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TCalcTransport.java
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Dummy transport used for calculating size of metrics only.
  */
 public class TCalcTransport extends TTransport {
-    private AtomicInteger size = new AtomicInteger(0);
+    private final AtomicInteger size = new AtomicInteger(0);
 
     /**
      * Dummy override to satisfy interface. Not used for our purposes.

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TMultiUdpClient.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TMultiUdpClient.java
@@ -30,7 +30,7 @@ import java.net.SocketException;
  * A Thrift transport that sends to multiple connections
  */
 public class TMultiUdpClient extends TTransport implements AutoCloseable {
-    private TTransport[] transports;
+    private final TTransport[] transports;
 
     public TMultiUdpClient(SocketAddress[] socketAddresses) throws SocketException {
         if (socketAddresses == null || socketAddresses.length == 0) {

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpServer.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpServer.java
@@ -29,7 +29,7 @@ import java.net.SocketException;
  * A server for receiving data via Thrift UDP.
  */
 public class TUdpServer extends TUdpTransport implements AutoCloseable {
-    private int timeoutMillis;
+    private final int timeoutMillis;
 
     /**
      * Constructs a UDP server with the given host and port. Defaults to zero timeout.

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -52,7 +52,7 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
     private final Object receiveLock = new Object();
 
     @GuardedBy("receiveLock")
-    private ByteBuffer receiveBuffer;
+    private final ByteBuffer receiveBuffer;
 
     // NOTE: This is used in tests
     TUdpTransport(SocketAddress socketAddress, DatagramSocket socket) {

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -50,15 +50,15 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class M3ReporterTest {
-    private static double EPSILON = 1e-9;
-
-    private static SocketAddress socketAddress;
+    private static final double EPSILON = 1e-9;
 
     private static final ImmutableMap<String, String> DEFAULT_TAGS =
         ImmutableMap.of(
             "env", "test",
             "host", "test-host"
         );
+
+    private static SocketAddress socketAddress;
 
     @BeforeClass
     public static void setup() {
@@ -74,12 +74,7 @@ public class M3ReporterTest {
         final MockM3Server server = new MockM3Server(3, socketAddress);
         M3Reporter reporter = null;
 
-        Thread serverThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                server.serve();
-            }
-        });
+        Thread serverThread = new Thread(server::serve);
 
         try {
             serverThread.start();
@@ -231,12 +226,7 @@ public class M3ReporterTest {
     public void reporterFinalFlush() throws InterruptedException {
         final MockM3Server server = new MockM3Server(1, socketAddress);
 
-        Thread serverThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                server.serve();
-            }
-        });
+        Thread serverThread = new Thread(server::serve);
 
         serverThread.start();
 
@@ -260,12 +250,7 @@ public class M3ReporterTest {
     public void reporterAfterCloseNoThrow() throws InterruptedException {
         final MockM3Server server = new MockM3Server(0, socketAddress);
 
-        Thread serverThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                server.serve();
-            }
-        });
+        Thread serverThread = new Thread(server::serve);
 
         try {
             serverThread.start();
@@ -288,12 +273,7 @@ public class M3ReporterTest {
     public void reporterHistogramDurations() throws InterruptedException {
         final MockM3Server server = new MockM3Server(2, socketAddress);
 
-        Thread serverThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                server.serve();
-            }
-        });
+        Thread serverThread = new Thread(server::serve);
 
         serverThread.start();
 
@@ -386,12 +366,7 @@ public class M3ReporterTest {
     public void reporterHistogramValues() throws InterruptedException {
         final MockM3Server server = new MockM3Server(2, socketAddress);
 
-        Thread serverThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                server.serve();
-            }
-        });
+        Thread serverThread = new Thread(server::serve);
 
         try {
             serverThread.start();
@@ -508,17 +483,17 @@ public class M3ReporterTest {
 
         // NOTE: We're using default max packet size
         M3Reporter reporter = new M3Reporter.Builder(socketAddress)
-                .service("test-service")
-                .commonTags(
-                        ImmutableMap.of("env", "test")
-                )
-                // Effectively disable time-based flushing to only keep
-                // size-based one
-                .maxProcessorWaitUntilFlushMillis(1_000_000)
-                .build();
+            .service("test-service")
+            .commonTags(
+                ImmutableMap.of("env", "test")
+            )
+            // Effectively disable time-based flushing to only keep
+            // size-based one
+            .maxProcessorWaitUntilFlushMillis(1_000_000)
+            .build();
 
         ImmutableMap<String, String> emptyTags =
-                new ImmutableMap.Builder<String, String>(0).build();
+            new ImmutableMap.Builder<String, String>(0).build();
 
         for (int i = 0; i < expectedMetricsCount; ++i) {
             // NOTE: The goal is to minimize the metric size, to make sure

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Server.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Server.java
@@ -40,9 +40,9 @@ public class MockM3Server {
 
     private final CountDownLatch expectedMetricsLatch;
 
-    private TProcessor processor;
-    private TTransport transport;
-    private MockM3Service service;
+    private final TProcessor processor;
+    private final TTransport transport;
+    private final MockM3Service service;
 
     public MockM3Server(
         int expectedMetricsCount,

--- a/m3/src/test/java/com/uber/m3/tally/m3/SizedMetricTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/SizedMetricTest.java
@@ -24,6 +24,7 @@ import com.uber.m3.thrift.gen.Metric;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class SizedMetricTest {
     @Test
@@ -40,7 +41,7 @@ public class SizedMetricTest {
     public void nullSizedMetric() {
         SizedMetric sizedMetric = new SizedMetric(null, 9);
 
-        assertEquals(sizedMetric.getMetric(), null);
+        assertNull(sizedMetric.getMetric());
         assertEquals(sizedMetric.getSize(), 9);
     }
 

--- a/m3/src/test/java/com/uber/m3/tally/m3/TCalcTransportTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/TCalcTransportTest.java
@@ -27,9 +27,10 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class TCalcTransportTest {
-    TCalcTransport transport;
+    private TCalcTransport transport;
 
     @Before
     public void setUp() {
@@ -50,7 +51,7 @@ public class TCalcTransportTest {
             transport.open();
         } catch (TTransportException e) {
             // Should not reach here
-            assertTrue(false);
+            fail();
         }
     }
 
@@ -66,7 +67,7 @@ public class TCalcTransportTest {
             assertEquals(0, transport.read(null, 0, 0));
         } catch (TTransportException e) {
             // Should not reach here
-            assertTrue(false);
+            fail();
         }
     }
 
@@ -99,7 +100,7 @@ public class TCalcTransportTest {
             assertEquals(0, transport.getSize());
         } catch (TTransportException e) {
             // Should not reach here
-            assertTrue(false);
+            fail();
         }
     }
 }

--- a/m3/src/test/java/com/uber/m3/tally/m3/thrift/TUdpClientTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/thrift/TUdpClientTest.java
@@ -32,7 +32,10 @@ import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.util.stream.Stream;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class TUdpClientTest {
 
@@ -43,9 +46,9 @@ public class TUdpClientTest {
         TUdpClient client = createUdpClient(mockedSocket);
 
         byte[][] payloads =
-                Stream.of("0xDEEDDEED", "0xABBAABBA")
-                    .map(p -> p.getBytes(Charsets.US_ASCII))
-                    .toArray(byte[][]::new);
+            Stream.of("0xDEEDDEED", "0xABBAABBA")
+                .map(p -> p.getBytes(Charsets.US_ASCII))
+                .toArray(byte[][]::new);
 
         for (byte[] writtenBytes : payloads) {
             client.write(writtenBytes);
@@ -64,7 +67,7 @@ public class TUdpClientTest {
         ArgumentCaptor<DatagramPacket> argCaptor = ArgumentCaptor.forClass(DatagramPacket.class);
 
         verify(mockedSocket, times(1))
-                .send(argCaptor.capture());
+            .send(argCaptor.capture());
 
         DatagramPacket sentPacket = argCaptor.getValue();
 
@@ -75,8 +78,8 @@ public class TUdpClientTest {
         Assert.assertEquals(expectedPayload.length, sentPacket.getLength());
         Assert.assertEquals(0, sentPacket.getOffset());
         Assert.assertEquals(
-                new String(expectedPayload, Charsets.US_ASCII),
-                new String(sentPacket.getData(), sentPacket.getOffset(), sentPacket.getLength(), Charsets.US_ASCII)
+            new String(expectedPayload, Charsets.US_ASCII),
+            new String(sentPacket.getData(), sentPacket.getOffset(), sentPacket.getLength(), Charsets.US_ASCII)
         );
     }
 

--- a/statsd/src/main/java/com/uber/m3/tally/statsd/StatsdAssertingUdpServer.java
+++ b/statsd/src/main/java/com/uber/m3/tally/statsd/StatsdAssertingUdpServer.java
@@ -29,10 +29,11 @@ import java.net.UnknownHostException;
 import java.util.Set;
 
 public class StatsdAssertingUdpServer implements Runnable {
-    private final int TIMEOUT_MILLIS = 1000;
-    private final int RECEIVE_MAX_SIZE = 1024;
+    private static final int TIMEOUT_MILLIS = 1000;
+    private static final int RECEIVE_MAX_SIZE = 1024;
+
     private final SocketAddress socketAddress;
-    private Set<String> expectedStrs;
+    private final Set<String> expectedStrs;
 
     StatsdAssertingUdpServer(String hostname, int port, Set<String> expectedStrs) {
         this.expectedStrs = expectedStrs;

--- a/statsd/src/main/java/com/uber/m3/tally/statsd/StatsdReporter.java
+++ b/statsd/src/main/java/com/uber/m3/tally/statsd/StatsdReporter.java
@@ -36,9 +36,9 @@ public class StatsdReporter implements StatsReporter {
     private static final int DEFAULT_SAMPLE_RATE = 1;
     private static final int DEFAULT_HISTOGRAM_BUCKET_NAME_PRECISION = 6;
 
-    private StatsDClient statsdClient;
-    private double sampleRate;
-    private String bucketFmt;
+    private final StatsDClient statsdClient;
+    private final double sampleRate;
+    private final String bucketFmt;
 
     /**
      * Create a StatsD reporter

--- a/statsd/src/test/java/com/uber/m3/tally/statsd/StatsdReporterTest.java
+++ b/statsd/src/test/java/com/uber/m3/tally/statsd/StatsdReporterTest.java
@@ -34,7 +34,7 @@ import java.util.HashSet;
 import static org.junit.Assert.assertEquals;
 
 public class StatsdReporterTest {
-    private final int PORT = 4434;
+    private static final int PORT = 4434;
 
     private StatsDClient statsd;
     private StatsdReporter reporter;


### PR DESCRIPTION
Java 8 code cleanup includes:
- Creating `final` fields.
- Using `ConcurrentHashMap` methods.
- Having consistent formatting.
- Using generics.
- Using JUnit `Assert.assert*()` methods.