### PR TITLE
NoopScope created with NullStatsReporter

### DIFF
--- a/core/src/main/java/com/uber/m3/tally/NullStatsReporter.java
+++ b/core/src/main/java/com/uber/m3/tally/NullStatsReporter.java
@@ -22,36 +22,62 @@ package com.uber.m3.tally;
 
 import com.uber.m3.util.Duration;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
+import java.util.Map;
 
 /**
- * Noop implementation of Scope.
+ * NullStatsReporter is a noop implementation of StatsReporter.
  */
-public class NoopScope extends ScopeImpl {
-
-    private NoopScope(ScheduledExecutorService scheduler, Registry registry, ScopeBuilder builder) {
-        super(scheduler, registry, builder);
+public class NullStatsReporter implements StatsReporter {
+    @Override
+    public void reportCounter(String name, Map<String, String> tags, long value) {
+        // noop
     }
 
-    /**
-     * Creates a new NoopScope.
-     */
-    public static NoopScope create() {
-        return (NoopScope) new NoopScopeBuilder()
-            .reporter(new NullStatsReporter())
-            .reportEvery(Duration.ZERO);
+    @Override
+    public void reportGauge(String name, Map<String, String> tags, double value) {
+        // noop
     }
 
-    private static class NoopScopeBuilder extends ScopeBuilder {
+    @Override
+    public void reportTimer(String name, Map<String, String> tags, Duration interval) {
+        // noop
+    }
 
-        public NoopScopeBuilder() {
-            super(Executors.newSingleThreadScheduledExecutor(), new ScopeImpl.Registry());
-        }
+    @Override
+    public void reportHistogramValueSamples(
+        String name, Map<String,
+        String> tags,
+        Buckets buckets,
+        double bucketLowerBound,
+        double bucketUpperBound,
+        long samples
+    ) {
+        // noop
+    }
 
-        @Override
-        ScopeImpl build() {
-            return new NoopScope(scheduler, registry, this);
-        }
+    @Override
+    public void reportHistogramDurationSamples(
+        String name,
+        Map<String, String> tags,
+        Buckets buckets,
+        Duration bucketLowerBound,
+        Duration bucketUpperBound, long samples
+    ) {
+        // noop
+    }
+
+    @Override
+    public Capabilities capabilities() {
+        return CapableOf.NONE;
+    }
+
+    @Override
+    public void flush() {
+        // noop
+    }
+
+    @Override
+    public void close() {
+        // noop
     }
 }

--- a/core/src/test/java/com/uber/m3/tally/NoopScopeTest.java
+++ b/core/src/test/java/com/uber/m3/tally/NoopScopeTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Uber Technologies, Inc.
+// Copyright (c) 2020 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,141 +20,21 @@
 
 package com.uber.m3.tally;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 public class NoopScopeTest {
 
     @Test
-    public void testCounter() {
-        NoopScope noopScope = new NoopScope();
-        Counter noopCounter1 = noopScope.counter("test1");
-        Counter noopCounter2 = noopScope.counter("test2");
-        Assert.assertThat(
-                "same noop counter returned",
-                noopCounter1 == noopCounter2,
-                CoreMatchers.equalTo(true)
-        );
-        Assert.assertThat(
-                "noop counter",
-                noopCounter1 == NoopScope.NOOP_COUNTER,
-                CoreMatchers.equalTo(true)
-        );
-    }
-
-    @Test
-    public void testGauge() {
-        NoopScope noopScope = new NoopScope();
-        Gauge noopGauge1 = noopScope.gauge("test1");
-        Gauge noopGauge2 = noopScope.gauge("test2");
-        Assert.assertThat(
-                "same noop gauge returned",
-                noopGauge1 == noopGauge2,
-                CoreMatchers.equalTo(true)
-        );
-        Assert.assertThat(
-                "noop gauge",
-                noopGauge1 == NoopScope.NOOP_GAUGE,
-                CoreMatchers.equalTo(true)
-        );
-    }
-
-    @Test
-    public void testTimer() {
-        NoopScope noopScope = new NoopScope();
-        Timer noopTimer1 = noopScope.timer("test1");
-        Timer noopTimer2 = noopScope.timer("test2");
-        Assert.assertThat(
-                "same noop timer returned",
-                noopTimer1 == noopTimer2,
-                CoreMatchers.equalTo(true)
-        );
-        Assert.assertThat(
-                "noop timer",
-                noopTimer1 == NoopScope.NOOP_TIMER,
-                CoreMatchers.equalTo(true)
-        );
-        Assert.assertThat(
-                "noop stopwatch",
-                noopTimer1.start() == NoopScope.NOOP_STOPWATCH,
-                CoreMatchers.equalTo(true)
-        );
-    }
-
-    @Test
-    public void testHistogram() {
-        NoopScope noopScope = new NoopScope();
-        Histogram noopHistogram1 = noopScope.histogram("test1", ValueBuckets.custom(1, 2, 3));
-        Histogram noopHistogram2 = noopScope.histogram("test2", ValueBuckets.custom(4, 5, 6));
-
-        Assert.assertThat(
-                "same noop histogram returned",
-                noopHistogram1 == noopHistogram2,
-                CoreMatchers.equalTo(true)
-        );
-        Assert.assertThat(
-                "noop histogram",
-                noopHistogram1 == NoopScope.NOOP_HISTOGRAM,
-                CoreMatchers.equalTo(true)
-        );
-    }
-
-    @Test
-    public void testCapabilities() {
-        NoopScope noopScope = new NoopScope();
-        Capabilities noopCapabilities1 = noopScope.capabilities();
-        Capabilities noopCapabilities2 = noopScope.capabilities();
-        Assert.assertThat(
-                "same noop capabilities returned",
-                noopCapabilities1 == noopCapabilities2,
-                CoreMatchers.equalTo(true)
-        );
-        Assert.assertThat(
-                "noop capabilities",
-                noopCapabilities1 == NoopScope.NOOP_CAPABILITIES,
-                CoreMatchers.equalTo(true)
-        );
-    }
-
-    @Test
-    public void testSubscope() {
-        NoopScope noopScope = new NoopScope();
-        Scope noopScope1 = noopScope.subScope("test1");
-        Scope noopScope2 = noopScope.subScope("test2");
-        Assert.assertThat("same noop scope returned",
-                noopScope1 == noopScope2,
-                CoreMatchers.equalTo(true)
-        );
-        Assert.assertThat("noop scope returned",
-                noopScope1 == noopScope,
-                CoreMatchers.equalTo(true)
-        );
-    }
-
-    @Test
-    public void testTagged() {
-        NoopScope noopScope = new NoopScope();
-        Map<String, String> tagMap1 = new HashMap<>(2);
-        tagMap1.put("A", "1");
-        tagMap1.put("B", "2");
-
-        Map<String, String> tagMap2 = new HashMap<>(2);
-        tagMap1.put("C", "3");
-        tagMap1.put("D", "4");
-
-        Scope noopScope1 = noopScope.tagged(tagMap1);
-        Scope noopScope2 = noopScope.tagged(tagMap2);
-        Assert.assertThat("same noop scope returned",
-                noopScope1 == noopScope2,
-                CoreMatchers.equalTo(true)
-        );
-        Assert.assertThat("noop scope returned",
-                noopScope1 == noopScope,
-                CoreMatchers.equalTo(true)
-        );
+    public void getInstance() {
+        Scope scope = NoopScope.create();
+        assertThat(scope, instanceOf(NoopScope.class));
+        assertNotNull(scope.capabilities());
+        assertFalse(scope.capabilities().reporting());
+        assertFalse(scope.capabilities().tagging());
     }
 }

--- a/core/src/test/java/com/uber/m3/tally/NullStatsReporterTest.java
+++ b/core/src/test/java/com/uber/m3/tally/NullStatsReporterTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,38 +20,18 @@
 
 package com.uber.m3.tally;
 
-import com.uber.m3.util.Duration;
+import org.junit.Test;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
-/**
- * Noop implementation of Scope.
- */
-public class NoopScope extends ScopeImpl {
+public class NullStatsReporterTest {
 
-    private NoopScope(ScheduledExecutorService scheduler, Registry registry, ScopeBuilder builder) {
-        super(scheduler, registry, builder);
-    }
-
-    /**
-     * Creates a new NoopScope.
-     */
-    public static NoopScope create() {
-        return (NoopScope) new NoopScopeBuilder()
-            .reporter(new NullStatsReporter())
-            .reportEvery(Duration.ZERO);
-    }
-
-    private static class NoopScopeBuilder extends ScopeBuilder {
-
-        public NoopScopeBuilder() {
-            super(Executors.newSingleThreadScheduledExecutor(), new ScopeImpl.Registry());
-        }
-
-        @Override
-        ScopeImpl build() {
-            return new NoopScope(scheduler, registry, this);
-        }
+    @Test
+    public void capabilities() {
+        NullStatsReporter reporter = new NullStatsReporter();
+        assertNotNull(reporter.capabilities());
+        assertFalse(reporter.capabilities().reporting());
+        assertFalse(reporter.capabilities().tagging());
     }
 }

--- a/core/src/test/java/com/uber/m3/tally/ScopeImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/ScopeImplTest.java
@@ -20,19 +20,18 @@
 
 package com.uber.m3.tally;
 
+import com.uber.m3.util.Duration;
+import com.uber.m3.util.ImmutableMap;
+import org.junit.Test;
+
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
-
-import com.uber.m3.util.Duration;
-import com.uber.m3.util.ImmutableMap;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 public class ScopeImplTest {
     private static final double EPSILON = 1e-10;
@@ -54,21 +53,21 @@ public class ScopeImplTest {
 
         Counter sameCounter = scope.counter("new-counter");
         // Should be the same Counter object and not a new instance
-        assertTrue(counter == sameCounter);
+        assertEquals(counter, sameCounter);
 
         Gauge gauge = scope.gauge("new-gauge");
         assertNotNull(gauge);
 
         Gauge sameGauge = scope.gauge("new-gauge");
         // Should be the same Gauge object and not a new instance
-        assertTrue(gauge == sameGauge);
+        assertEquals(gauge, sameGauge);
 
         Timer timer = scope.timer("new-timer");
         assertNotNull(timer);
 
         Timer sameTimer = scope.timer("new-timer");
         // Should be the same Timer object and not a new instance
-        assertTrue(timer == sameTimer);
+        assertEquals(timer, sameTimer);
 
         Histogram histogram = scope.histogram(
             "new-histogram",
@@ -78,7 +77,7 @@ public class ScopeImplTest {
 
         Histogram sameHistogram = scope.histogram("new-histogram", null);
         // Should be the same Histogram object and not a new instance
-        assertTrue(histogram == sameHistogram);
+        assertEquals(histogram, sameHistogram);
     }
 
     @Test
@@ -151,9 +150,9 @@ public class ScopeImplTest {
 
         ImmutableMap<String, String> additionalTags =
             new ImmutableMap.Builder<String, String>(2)
-            .put("new_key", "new_val")
-            .put("baz", "quz")
-            .build();
+                .put("new_key", "new_val")
+                .put("baz", "quz")
+                .build();
         Scope taggedSubscope = rootScope.tagged(additionalTags);
         Timer taggedTimer = taggedSubscope.timer("tagged_timer");
         taggedTimer.record(Duration.ofSeconds(6));
@@ -180,9 +179,9 @@ public class ScopeImplTest {
         assertEquals("tagged_timer", timer.getName());
         ImmutableMap<String, String> expectedTags =
             new ImmutableMap.Builder<String, String>(4)
-            .putAll(tags)
-            .putAll(additionalTags)
-            .build();
+                .putAll(tags)
+                .putAll(additionalTags)
+                .build();
         assertEquals(expectedTags, timer.getTags());
     }
 
@@ -222,28 +221,40 @@ public class ScopeImplTest {
         Map<String, CounterSnapshot> counters = snapshot.counters();
         assertEquals(1, counters.size());
         assertEquals("snapshot-counter", counters.get("snapshot-counter+").name());
-        assertEquals(null, counters.get("snapshot-counter+").tags());
+        assertNull(counters.get("snapshot-counter+").tags());
 
         Map<String, GaugeSnapshot> gauges = snapshot.gauges();
         assertEquals(3, gauges.size());
         assertEquals("snapshot-gauge", gauges.get("snapshot-gauge+").name());
-        assertEquals(null, gauges.get("snapshot-gauge+").tags());
+        assertNull(gauges.get("snapshot-gauge+").tags());
         assertEquals(120, gauges.get("snapshot-gauge+").value(), EPSILON);
         assertEquals("snapshot-gauge2", gauges.get("snapshot-gauge2+").name());
-        assertEquals(null, gauges.get("snapshot-gauge2+").tags());
+        assertNull(gauges.get("snapshot-gauge2+").tags());
         assertEquals(220, gauges.get("snapshot-gauge2+").value(), EPSILON);
         assertEquals("snapshot-gauge3", gauges.get("snapshot-gauge3+").name());
-        assertEquals(null, gauges.get("snapshot-gauge3+").tags());
+        assertNull(gauges.get("snapshot-gauge3+").tags());
         assertEquals(320, gauges.get("snapshot-gauge3+").value(), EPSILON);
 
         Map<String, TimerSnapshot> timers = snapshot.timers();
         assertEquals(1, timers.size());
         assertEquals("snapshot-timer", timers.get("snapshot-timer+").name());
-        assertEquals(null, timers.get("snapshot-timer+").tags());
+        assertNull(timers.get("snapshot-timer+").tags());
+    }
+
+    @Test
+    public void noopNullStatsReporter() {
+        new RootScopeBuilder().reporter(new NullStatsReporter()).reportEvery(Duration.ofSeconds(-10));
+        new RootScopeBuilder().reporter(new NullStatsReporter()).reportEvery(Duration.ZERO);
+        new RootScopeBuilder().reporter(new NullStatsReporter()).reportEvery(Duration.ofSeconds(10));
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void nonPositiveReportInterval() {
+    public void zeroReportInterval() {
+        new RootScopeBuilder().reportEvery(Duration.ZERO);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeReportInterval() {
         new RootScopeBuilder().reportEvery(Duration.ofSeconds(-10));
     }
 
@@ -251,19 +262,11 @@ public class ScopeImplTest {
     public void exceptionInReportLoop() throws ScopeCloseException, InterruptedException {
         final AtomicInteger uncaghtExceptionReported = new AtomicInteger();
         ThrowingStatsReporter reporter = new ThrowingStatsReporter();
-        final UncaughtExceptionHandler uncaughtExceptionHandler = new UncaughtExceptionHandler() {
-            @Override
-            public void uncaughtException(Thread t, Throwable e) {
-                uncaghtExceptionReported.incrementAndGet();
-            }
-        };
+        final UncaughtExceptionHandler uncaughtExceptionHandler = (t, e) -> uncaghtExceptionReported.incrementAndGet();
 
-        Scope scope = new RootScopeBuilder()
+        try (Scope scope = new RootScopeBuilder()
             .reporter(reporter)
-            .reportEvery(Duration.ofMillis(REPORT_INTERVAL_MILLIS),
-                uncaughtExceptionHandler);
-
-        try {
+            .reportEvery(Duration.ofMillis(REPORT_INTERVAL_MILLIS), uncaughtExceptionHandler)) {
             scope.counter("hi").inc(1);
             Thread.sleep(SLEEP_MILLIS);
 
@@ -276,15 +279,13 @@ public class ScopeImplTest {
 
             assertEquals(2, uncaghtExceptionReported.get());
             assertEquals(2, reporter.getNumberOfReportedMetrics());
-        } finally {
-            scope.close();
         }
     }
 
     private static class ThrowingStatsReporter implements StatsReporter {
         private final AtomicInteger reported = new AtomicInteger();
 
-        public int getNumberOfReportedMetrics() {
+        int getNumberOfReportedMetrics() {
             return reported.get();
         }
 
@@ -307,17 +308,27 @@ public class ScopeImplTest {
         }
 
         @Override
-        public void reportHistogramValueSamples(String name, Map<String, String> tags,
-                                                Buckets buckets, double bucketLowerBound,
-                                                double bucketUpperBound, long samples) {
+        public void reportHistogramValueSamples(
+            String name,
+            Map<String, String> tags,
+            Buckets buckets,
+            double bucketLowerBound,
+            double bucketUpperBound,
+            long samples
+        ) {
             reported.incrementAndGet();
             throw new RuntimeException();
         }
 
         @Override
-        public void reportHistogramDurationSamples(String name, Map<String, String> tags,
-                                                   Buckets buckets, Duration bucketLowerBound,
-                                                   Duration bucketUpperBound, long samples) {
+        public void reportHistogramDurationSamples(
+            String name,
+            Map<String, String> tags,
+            Buckets buckets,
+            Duration bucketLowerBound,
+            Duration bucketUpperBound,
+            long samples
+        ) {
             reported.incrementAndGet();
             throw new RuntimeException();
         }


### PR DESCRIPTION
- Created `NullStatsReporter`.
- Reporting is a noop when the `NullStatsReporter` is used by `ScopeBuilder`.
- The `NoopScope` is built using the `NullStatsReporter` and zero reporting interval, just like for `uber-go/tally`: https://github.com/uber-go/tally/blob/master/scope.go#L35.
