### PR TITLE
Adding Sanitizer interface and implementation

### DIFF
--- a/core/src/main/java/com/uber/m3/tally/ScopeBuilder.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeBuilder.java
@@ -20,6 +20,8 @@
 
 package com.uber.m3.tally;
 
+import com.uber.m3.tally.sanitizers.Sanitizer;
+import com.uber.m3.tally.sanitizers.SanitizerBuilder;
 import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
 
@@ -55,6 +57,7 @@ public class ScopeBuilder {
     protected String separator = DEFAULT_SEPARATOR;
     protected ImmutableMap<String, String> tags;
     protected Buckets defaultBuckets = DEFAULT_SCOPE_BUCKETS;
+    protected Sanitizer sanitizer = new SanitizerBuilder().build();
 
     private ScheduledExecutorService scheduler;
     private ScopeImpl.Registry registry;
@@ -125,6 +128,17 @@ public class ScopeBuilder {
      */
     public ScopeBuilder defaultBuckets(Buckets defaultBuckets) {
         this.defaultBuckets = defaultBuckets;
+        return this;
+    }
+
+    /**
+     * Update the sanitizer.
+     *
+     * @param sanitizer value to update to
+     * @return Builder with new param updated
+     */
+    public ScopeBuilder sanitizer(Sanitizer sanitizer) {
+        this.sanitizer = sanitizer;
         return this;
     }
 

--- a/core/src/main/java/com/uber/m3/tally/sanitizers/Sanitize.java
+++ b/core/src/main/java/com/uber/m3/tally/sanitizers/Sanitize.java
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally.sanitizers;
+
+/**
+ * Sanitize returns a sanitized version of the input string value.
+ */
+public interface Sanitize {
+
+    /**
+     * Sanitize the input string value.
+     * @param value input string value
+     * @return sanitized string value
+     */
+    String sanitize(String value);
+}

--- a/core/src/main/java/com/uber/m3/tally/sanitizers/SanitizeRange.java
+++ b/core/src/main/java/com/uber/m3/tally/sanitizers/SanitizeRange.java
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally.sanitizers;
+
+/**
+ * SanitizeRange is a range of characters (inclusive on both ends).
+ */
+public class SanitizeRange {
+
+    private final char low;
+    private final char high;
+
+    private SanitizeRange(char low, char high) {
+        this.low = low;
+        this.high = high;
+    }
+
+    public static SanitizeRange of(char low, char high) {
+        return new SanitizeRange(low, high);
+    }
+
+    char low() {
+        return low;
+    }
+
+    char high() {
+        return high;
+    }
+}

--- a/core/src/main/java/com/uber/m3/tally/sanitizers/Sanitizer.java
+++ b/core/src/main/java/com/uber/m3/tally/sanitizers/Sanitizer.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally.sanitizers;
+
+/**
+ * SanitizerImpl sanitizes the provided input based on the function executed.
+ */
+public interface Sanitizer {
+
+    /**
+     * Name sanitizes the provided 'name' string.
+     * @param name the name string
+     * @return the sanitized name
+     */
+    String name(String name);
+
+    /**
+     * Key sanitizes the provided 'key' string.
+     * @param key the key string
+     * @return the sanitized key
+     */
+    String key(String key);
+
+    /**
+     * Value sanitizes the provided 'value' string.
+     * @param value the value string
+     * @return the sanitized value
+     */
+    String value(String value);
+}

--- a/core/src/main/java/com/uber/m3/tally/sanitizers/SanitizerBuilder.java
+++ b/core/src/main/java/com/uber/m3/tally/sanitizers/SanitizerBuilder.java
@@ -1,0 +1,87 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally.sanitizers;
+
+/**
+ * The SanitizerBuilder returns a Sanitizer for the name, key and value. By
+ * default, the name, key and value sanitize functions returns all the input
+ * untouched. Custom name, key or value Sanitize functions or ValidCharacters
+ * can be provided to override their default behaviour.
+ */
+public class SanitizerBuilder {
+
+    private Sanitize nameSanitizer = value -> value;
+    private Sanitize keySanitizer = value -> value;
+    private Sanitize valueSanitizer = value -> value;
+
+    private char repChar = ValidCharacters.DEFAULT_REPLACEMENT_CHARACTER;
+    private ValidCharacters nameCharacters;
+    private ValidCharacters keyCharacters;
+    private ValidCharacters valueCharacters;
+
+    public SanitizerBuilder withNameSanitizer(Sanitize nameSanitizer) {
+        this.nameSanitizer = nameSanitizer;
+        return this;
+    }
+
+    public SanitizerBuilder withKeySanitizer(Sanitize keySanitizer) {
+        this.keySanitizer = keySanitizer;
+        return this;
+    }
+
+    public SanitizerBuilder withValueSanitizer(Sanitize valueSanitizer) {
+        this.valueSanitizer = valueSanitizer;
+        return this;
+    }
+
+    public SanitizerBuilder withReplacementCharacter(char repChar) {
+        this.repChar = repChar;
+        return this;
+    }
+
+    public SanitizerBuilder withNameCharacters(ValidCharacters nameCharacters) {
+        this.nameCharacters = nameCharacters;
+        return this;
+    }
+
+    public SanitizerBuilder withKeyCharacters(ValidCharacters keyCharacters) {
+        this.keyCharacters = keyCharacters;
+        return this;
+    }
+
+    public SanitizerBuilder withValueCharacters(ValidCharacters valueCharacters) {
+        this.valueCharacters = valueCharacters;
+        return this;
+    }
+
+    public Sanitizer build() {
+        if (nameCharacters != null) {
+            nameSanitizer = nameCharacters.sanitize(repChar);
+        }
+        if (keyCharacters != null) {
+            keySanitizer = keyCharacters.sanitize(repChar);
+        }
+        if (valueCharacters != null) {
+            valueSanitizer = valueCharacters.sanitize(repChar);
+        }
+        return new SanitizerImpl(nameSanitizer, keySanitizer, valueSanitizer);
+    }
+}

--- a/core/src/main/java/com/uber/m3/tally/sanitizers/SanitizerImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/sanitizers/SanitizerImpl.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally.sanitizers;
+
+/**
+ * SanitizerImpl sanitizes the provided input based on the function executed.
+ */
+class SanitizerImpl implements Sanitizer {
+
+    private final Sanitize nameSanitizer;
+    private final Sanitize keySanitizer;
+    private final Sanitize valueSanitizer;
+
+    SanitizerImpl(Sanitize nameSanitizer, Sanitize keySanitizer, Sanitize valueSanitizer) {
+        this.nameSanitizer = nameSanitizer;
+        this.keySanitizer = keySanitizer;
+        this.valueSanitizer = valueSanitizer;
+    }
+
+    /**
+     * Name sanitizes the provided 'name' string.
+     * @param name the name string
+     * @return the sanitized name
+     */
+    @Override
+    public String name(String name) {
+        return this.nameSanitizer.sanitize(name);
+    }
+
+    /**
+     * Key sanitizes the provided 'key' string.
+     * @param key the key string
+     * @return the sanitized key
+     */
+    @Override
+    public String key(String key) {
+        return this.keySanitizer.sanitize(key);
+    }
+
+    /**
+     * Value sanitizes the provided 'value' string.
+     * @param value the value string
+     * @return the sanitized value
+     */
+    @Override
+    public String value(String value) {
+        return this.valueSanitizer.sanitize(value);
+    }
+}

--- a/core/src/main/java/com/uber/m3/tally/sanitizers/ValidCharacters.java
+++ b/core/src/main/java/com/uber/m3/tally/sanitizers/ValidCharacters.java
@@ -1,0 +1,109 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally.sanitizers;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * ValidCharacters is a collection of valid characters.
+ */
+public class ValidCharacters {
+
+    /**
+     * DEFAULT_REPLACEMENT_CHARACTER is the default character used for replacements.
+     */
+    public static char DEFAULT_REPLACEMENT_CHARACTER = '_';
+
+    /**
+     * ALPHANUMERIC_RANGE is the range of alphanumeric characters.
+     */
+    public static final List<SanitizeRange> ALPHANUMERIC_RANGE =
+        Arrays.asList(
+            SanitizeRange.of('a', 'z'),
+            SanitizeRange.of('A', 'Z'),
+            SanitizeRange.of('0', '9'));
+
+    /**
+     * UNDERSCORE_CHARACTERS contains the underscore character.
+     */
+    public static final List<Character> UNDERSCORE_CHARACTERS = Collections.singletonList('_');
+
+    /**
+     * UNDERSCORE_DASH_CHARACTERS contains the underscore and dash characters.
+     */
+    public static final List<Character> UNDERSCORE_DASH_CHARACTERS = Arrays.asList('_', '-');
+
+    /**
+     * UNDERSCORE_DASH_DOT_CHARACTERS contains the underscore, dash and dot characters.
+     */
+    public static final List<Character> UNDERSCORE_DASH_DOT_CHARACTERS = Arrays.asList('_', '-', '.');
+
+    private final List<SanitizeRange> ranges;
+    private final List<Character> characters;
+
+    private ValidCharacters(List<SanitizeRange> ranges, List<Character> characters) {
+        this.ranges = ranges != null ? ranges : Collections.emptyList();
+        this.characters = characters != null ? characters : Collections.emptyList();
+    }
+
+    public static ValidCharacters of(List<SanitizeRange> ranges, List<Character> characters) {
+        return new ValidCharacters(ranges, characters);
+    }
+
+    Sanitize sanitize(char repChar) {
+        return value -> {
+            StringBuilder buffer = null;
+
+            for (int i = 0; i < value.length(); i++) {
+                char ch = value.charAt(i);
+
+                // first check if the provided character is valid
+                boolean validCurr =
+                    ranges.stream().anyMatch(range -> ch >= range.low() && ch <= range.high())
+                        || characters.stream().anyMatch(character -> character.equals(ch));
+
+                // if it's valid, we can optimize allocations by avoiding copying
+                if (validCurr) {
+                    if (buffer != null) {
+                        buffer.append(ch);
+                    }
+                    continue;
+                }
+
+                // the character is invalid, and the buffer has not been initialized
+                // so we initialize the buffer and back-fill.
+                if (buffer == null) {
+                    buffer = new StringBuilder(value.length());
+                    buffer.append(value, 0, i);
+                }
+
+                // write the replacement character
+                buffer.append(repChar);
+            }
+
+            // return input un-touched if the buffer has not been initialized
+            // otherwise, return the newly constructed buffer string
+            return buffer == null ? value : buffer.toString();
+        };
+    }
+}

--- a/core/src/test/java/com/uber/m3/tally/sanitizers/SanitizeRangeTest.java
+++ b/core/src/test/java/com/uber/m3/tally/sanitizers/SanitizeRangeTest.java
@@ -1,0 +1,40 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally.sanitizers;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class SanitizeRangeTest {
+
+    private static final char LOW = 'a';
+    private static final char HIGH = 'z';
+
+    @Test
+    public void sanitizeRange() {
+        SanitizeRange range = SanitizeRange.of(LOW, HIGH);
+        assertNotNull(range);
+        assertEquals(LOW, range.low());
+        assertEquals(HIGH, range.high());
+    }
+}

--- a/core/src/test/java/com/uber/m3/tally/sanitizers/SanitizerTest.java
+++ b/core/src/test/java/com/uber/m3/tally/sanitizers/SanitizerTest.java
@@ -1,0 +1,108 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally.sanitizers;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SanitizerTest {
+
+    private static final String NAME = "!@#$%^&*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.";
+    private static final String KEY = "!@#$%^&*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.";
+    private static final String VALUE = "!@#$%^&*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.";
+    private static final String SANITIZED_NAME_1 = "sanitized-name";
+    private static final String SANITIZED_KEY_1 = "sanitized-key";
+    private static final String SANITIZED_VALUE_1 = "sanitized-value";
+    private static final String SANITIZED_NAME_2 = "__________abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890___";
+    private static final String SANITIZED_KEY_2 = "__________abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-_";
+    private static final String SANITIZED_VALUE_2 = "__________abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.";
+    private static final String SANITIZED_NAME_3 = "@@@@@@@@@@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_@@";
+    private static final String SANITIZED_KEY_3 = "@@@@@@@@@@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-@";
+    private static final String SANITIZED_VALUE_3 = "@@@@@@@@@@abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.";
+    private static final char REPLACEMENT_CHAR = '@';
+
+    @Test
+    public void noopSanitizer() {
+        Sanitizer sanitizer = new SanitizerBuilder().build();
+        assertEquals(NAME, sanitizer.name(NAME));
+        assertEquals(KEY, sanitizer.key(KEY));
+        assertEquals(VALUE, sanitizer.value(VALUE));
+    }
+
+    @Test
+    public void withSanitizers() {
+        Sanitizer sanitizer =
+            new SanitizerBuilder()
+                .withNameSanitizer(value -> SANITIZED_NAME_1)
+                .withKeySanitizer(value -> SANITIZED_KEY_1)
+                .withValueSanitizer(value -> SANITIZED_VALUE_1)
+                .build();
+        assertEquals(SANITIZED_NAME_1, sanitizer.name(NAME));
+        assertEquals(SANITIZED_KEY_1, sanitizer.key(KEY));
+        assertEquals(SANITIZED_VALUE_1, sanitizer.value(VALUE));
+    }
+
+    @Test
+    public void withValidCharactersAndDefaultRepChar() {
+        Sanitizer sanitizer =
+            new SanitizerBuilder()
+                .withNameCharacters(
+                    ValidCharacters.of(
+                        ValidCharacters.ALPHANUMERIC_RANGE,
+                        ValidCharacters.UNDERSCORE_CHARACTERS))
+                .withKeyCharacters(
+                    ValidCharacters.of(
+                        ValidCharacters.ALPHANUMERIC_RANGE,
+                        ValidCharacters.UNDERSCORE_DASH_CHARACTERS))
+                .withValueCharacters(
+                    ValidCharacters.of(
+                        ValidCharacters.ALPHANUMERIC_RANGE,
+                        ValidCharacters.UNDERSCORE_DASH_DOT_CHARACTERS))
+                .build();
+        assertEquals(SANITIZED_NAME_2, sanitizer.name(NAME));
+        assertEquals(SANITIZED_KEY_2, sanitizer.key(KEY));
+        assertEquals(SANITIZED_VALUE_2, sanitizer.value(VALUE));
+    }
+
+    @Test
+    public void withValidCharactersAndRepChar() {
+        Sanitizer sanitizer =
+            new SanitizerBuilder()
+                .withReplacementCharacter(REPLACEMENT_CHAR)
+                .withNameCharacters(
+                    ValidCharacters.of(
+                        ValidCharacters.ALPHANUMERIC_RANGE,
+                        ValidCharacters.UNDERSCORE_CHARACTERS))
+                .withKeyCharacters(
+                    ValidCharacters.of(
+                        ValidCharacters.ALPHANUMERIC_RANGE,
+                        ValidCharacters.UNDERSCORE_DASH_CHARACTERS))
+                .withValueCharacters(
+                    ValidCharacters.of(
+                        ValidCharacters.ALPHANUMERIC_RANGE,
+                        ValidCharacters.UNDERSCORE_DASH_DOT_CHARACTERS))
+                .build();
+        assertEquals(SANITIZED_NAME_3, sanitizer.name(NAME));
+        assertEquals(SANITIZED_KEY_3, sanitizer.key(KEY));
+        assertEquals(SANITIZED_VALUE_3, sanitizer.value(VALUE));
+    }
+}

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Sanitizer.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Sanitizer.java
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally.m3;
+
+import com.uber.m3.tally.sanitizers.Sanitizer;
+import com.uber.m3.tally.sanitizers.SanitizerBuilder;
+import com.uber.m3.tally.sanitizers.ValidCharacters;
+
+public class M3Sanitizer {
+
+    /**
+     * Creates the default M3 sanitizer.
+     * @return default M3 sanitizer
+     */
+    public static Sanitizer create() {
+        return new SanitizerBuilder()
+            .withReplacementCharacter(ValidCharacters.DEFAULT_REPLACEMENT_CHARACTER)
+            .withNameCharacters(
+                ValidCharacters.of(
+                    ValidCharacters.ALPHANUMERIC_RANGE,
+                    ValidCharacters.UNDERSCORE_DASH_DOT_CHARACTERS))
+            .withKeyCharacters(
+                ValidCharacters.of(
+                    ValidCharacters.ALPHANUMERIC_RANGE,
+                    ValidCharacters.UNDERSCORE_DASH_CHARACTERS))
+            .withValueCharacters(
+                ValidCharacters.of(
+                    ValidCharacters.ALPHANUMERIC_RANGE,
+                    ValidCharacters.UNDERSCORE_DASH_DOT_CHARACTERS))
+            .build();
+    }
+}

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3SanitizerTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3SanitizerTest.java
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally.m3;
+
+import com.uber.m3.tally.sanitizers.Sanitizer;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class M3SanitizerTest {
+
+    private static final String NAME = "!@#$%^&*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.";
+    private static final String KEY = "!@#$%^&*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.";
+    private static final String VALUE = "!@#$%^&*()abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.";
+    private static final String SANITIZED_NAME = "__________abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.";
+    private static final String SANITIZED_KEY = "__________abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-_";
+    private static final String SANITIZED_VALUE = "__________abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_-.";
+
+    @Test
+    public void m3Sanitizer() {
+        Sanitizer sanitizer = M3Sanitizer.create();
+        assertNotNull(sanitizer);
+        assertEquals(SANITIZED_NAME, sanitizer.name(NAME));
+        assertEquals(SANITIZED_KEY, sanitizer.key(KEY));
+        assertEquals(SANITIZED_VALUE, sanitizer.value(VALUE));
+    }
+}


### PR DESCRIPTION
- Sanitizes metric names and tag keys and values.
- Does nothing by default.
- The `ScopeBulider` can be configured with the standard `M3Sanitizer`.
- Fixes #8 