### PR TITLE
Fix M3Reporter.Processor Flaky Tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,15 @@ allprojects {
     }
 
     dependencies {
-        testCompile('junit:junit:4.12')
-        testCompile "org.mockito:mockito-core:[1.0, 2.0)"
+        testCompile 'junit:junit:4.12'
+        testCompile 'org.mockito:mockito-core:[1.0, 2.0)'
+        testCompile 'ch.qos.logback:logback-classic:1.2.3'
+        testCompile 'ch.qos.logback:logback-core:1.2.3'
+    }
+
+    test {
+        testLogging.showStandardStreams = true
+        testLogging.exceptionFormat = 'full'
     }
 
     ext.ossrhUsername = System.getenv('OSSRH_JIRA_USERNAME')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 # DO NOT REMOVE - USED FOR INTERNAL TRACKING
 devexp.template.version = 'lib-1.0.0'
-org.gradle.logging.level=debug

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 # DO NOT REMOVE - USED FOR INTERNAL TRACKING
 devexp.template.version = 'lib-1.0.0'
+org.gradle.logging.level=debug

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -475,6 +475,8 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
             transport.open();
 
             client = new M3.Client(protocolFactory.getProtocol(transport));
+
+            LOG.info("Booted reporting processor");
         }
 
         @Override

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -104,13 +104,13 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
     private static final ThreadLocal<SerializedPayloadSizeEstimator> PAYLOAD_SIZE_ESTIMATOR =
             ThreadLocal.withInitial(SerializedPayloadSizeEstimator::new);
 
-    private Duration maxBufferingDelay;
+    private final Duration maxBufferingDelay;
 
     private final int payloadCapacity;
 
-    private String bucketIdTagName;
-    private String bucketTagName;
-    private String bucketValFmt;
+    private final String bucketIdTagName;
+    private final String bucketTagName;
+    private final String bucketValFmt;
 
     private final Set<MetricTag> commonTags;
 
@@ -123,9 +123,9 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
     // This is a synchronization barrier to make sure that reporter
     // is being shutdown only after all of its processor had done so
-    private CountDownLatch shutdownLatch = new CountDownLatch(NUM_PROCESSORS);
+    private final CountDownLatch shutdownLatch = new CountDownLatch(NUM_PROCESSORS);
 
-    private AtomicBoolean isShutdown = new AtomicBoolean(false);
+    private final AtomicBoolean isShutdown = new AtomicBoolean(false);
 
     // Use inner Builder class to construct an M3Reporter
     private M3Reporter(Builder builder) {

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -448,6 +448,14 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
         }
     }
 
+    private static void runNoThrow(ThrowingRunnable r) {
+        try {
+            r.run();
+        } catch (Throwable t) {
+            // no-op
+        }
+    }
+
     private class Processor implements Runnable {
 
         private final List<Metric> metricsBuffer =
@@ -578,14 +586,6 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
         public void scheduleFlush() {
             shouldFlush.set(true);
-        }
-    }
-
-    private static void runNoThrow(ThrowingRunnable r) {
-        try {
-            r.run();
-        } catch (Throwable t) {
-            // no-op
         }
     }
 

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -99,6 +99,11 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
     private static final int MIN_METRIC_BUCKET_ID_TAG_LENGTH = 4;
 
+    /**
+     * NOTE: DO NOT CHANGE THIS NUMBER!
+     *       Reporter architecture is not suited for multi-processor setup and might cause some disruption
+     *       to how metrics are processed and eventually submitted to M3 collectors;
+     */
     private static final int NUM_PROCESSORS = 1;
 
     private static final ThreadLocal<SerializedPayloadSizeEstimator> PAYLOAD_SIZE_ESTIMATOR =

--- a/m3/src/main/java/com/uber/m3/tally/m3/SizedMetric.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/SizedMetric.java
@@ -27,7 +27,6 @@ import com.uber.m3.thrift.gen.Metric;
  */
 public class SizedMetric extends Metric {
     public static final SizedMetric FLUSH = new SizedMetric(null, -1);
-    public static final SizedMetric CLOSE = new SizedMetric(null, -2);
 
     private Metric metric;
     private int size;

--- a/m3/src/main/java/com/uber/m3/tally/m3/SizedMetric.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/SizedMetric.java
@@ -26,8 +26,6 @@ import com.uber.m3.thrift.gen.Metric;
  * A metric along with its associated size.
  */
 public class SizedMetric extends Metric {
-    public static final SizedMetric FLUSH = new SizedMetric(null, -1);
-
     private Metric metric;
     private int size;
 

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
@@ -50,6 +50,8 @@ public class TUdpClient extends TUdpTransport implements AutoCloseable {
     public void open() throws TTransportException {
         try {
             socket.connect(socketAddress);
+
+            logger.info("UDP socket has been opened");
         } catch (SocketException e) {
             throw new TTransportException("Error opening transport", e);
         }

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpServer.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpServer.java
@@ -57,6 +57,8 @@ public class TUdpServer extends TUdpTransport implements AutoCloseable {
         try {
             socket.bind(socketAddress);
             socket.setSoTimeout(timeoutMillis);
+
+            logger.info("UDP socket has been bound to");
         } catch (SocketException e) {
             throw new TTransportException("Error opening transport", e);
         }

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -23,6 +23,8 @@ package com.uber.m3.tally.m3.thrift;
 import org.apache.http.annotation.GuardedBy;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -40,6 +42,8 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
     //       network configurations therefore setting payload size to be no more than:
     //       65535 - 512 = 65023 bytes
     public static final int PACKET_DATA_PAYLOAD_MAX_SIZE = 65023;
+
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     protected final Object sendLock = new Object();
 
@@ -82,6 +86,8 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
     @Override
     public void close() {
         socket.close();
+
+        logger.info("UDP socket has been closed");
     }
 
     @Override

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -113,7 +113,7 @@ public class M3ReporterTest {
 
                 // Shutdown both reporter and server
                 reporter.close();
-                server.await(MAX_WAIT_TIMEOUT);
+                server.awaitReceiving(MAX_WAIT_TIMEOUT);
 
                 receivedBatches = server.getService().snapshotBatches();
                 receivedMetrics = server.getService().snapshotMetrics();
@@ -221,7 +221,7 @@ public class M3ReporterTest {
                 reporter.reportTimer("final-flush-timer", null, Duration.ofMillis(10));
                 reporter.close();
 
-                server.await(MAX_WAIT_TIMEOUT);
+                server.awaitReceiving(MAX_WAIT_TIMEOUT);
 
                 List<MetricBatch> batches = server.getService().snapshotBatches();
                 assertEquals(1, batches.size());
@@ -273,7 +273,7 @@ public class M3ReporterTest {
                 );
 
                 reporter.close();
-                server.await(MAX_WAIT_TIMEOUT);
+                server.awaitReceiving(MAX_WAIT_TIMEOUT);
 
                 receivedBatches = server.getService().snapshotBatches();
             }
@@ -363,7 +363,7 @@ public class M3ReporterTest {
                 );
 
                 reporter.close();
-                server.await(MAX_WAIT_TIMEOUT);
+                server.awaitReceiving(MAX_WAIT_TIMEOUT);
 
                 receivedBatches = server.getService().snapshotBatches();
             }
@@ -432,9 +432,10 @@ public class M3ReporterTest {
         assertEquals(CapableOf.REPORTING_TAGGING, reporter.capabilities());
     }
 
-    private static MockM3Server bootM3Collector(int expectedMetricsCount) {
+    private static MockM3Server bootM3Collector(int expectedMetricsCount) throws InterruptedException {
         final MockM3Server server = new MockM3Server(expectedMetricsCount, socketAddress);
         new Thread(server::serve).start();
+        server.awaitStarting();
         return server;
     }
 
@@ -473,7 +474,7 @@ public class M3ReporterTest {
                 // Shutdown reporter
                 reporter.close();
 
-                server.await(MAX_WAIT_TIMEOUT);
+                server.awaitReceiving(MAX_WAIT_TIMEOUT);
 
                 metrics = server.getService().snapshotMetrics();
             }

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -129,7 +129,7 @@ public class M3ReporterTest {
                 reporter.close();
                 server.await();
 
-                receivedBatches = server.getService().getBatches();
+                receivedBatches = server.getService().snapshotBatches();
                 receivedMetrics = server.getService().snapshotMetrics();
             }
         }
@@ -236,7 +236,7 @@ public class M3ReporterTest {
 
             server.await();
 
-            List<MetricBatch> batches = server.getService().getBatches();
+            List<MetricBatch> batches = server.getService().snapshotBatches();
             assertEquals(1, batches.size());
             assertNotNull(batches.get(0));
             assertEquals(1, batches.get(0).getMetrics().size());
@@ -284,7 +284,7 @@ public class M3ReporterTest {
             reporter.close();
             server.await();
 
-            receivedBatches = server.getService().getBatches();
+            receivedBatches = server.getService().snapshotBatches();
         }
 
         assertEquals(1, receivedBatches.size());
@@ -371,7 +371,7 @@ public class M3ReporterTest {
             reporter.close();
             server.await();
 
-            receivedBatches = server.getService().getBatches();
+            receivedBatches = server.getService().snapshotBatches();
         }
 
         assertEquals(1, receivedBatches.size());

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -130,7 +130,7 @@ public class M3ReporterTest {
                 server.await();
 
                 receivedBatches = server.getService().getBatches();
-                receivedMetrics = server.getService().getMetrics();
+                receivedMetrics = server.getService().snapshotMetrics();
             }
         }
 
@@ -480,7 +480,7 @@ public class M3ReporterTest {
 
                 server.await();
 
-                metrics = server.getService().getMetrics();
+                metrics = server.getService().snapshotMetrics();
             }
         }
 

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -76,7 +76,6 @@ public class M3ReporterTest {
         socketAddress = new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 12345);
     }
 
-
     @Test
     public void reporter() throws InterruptedException {
         ImmutableMap<String, String> commonTags = new ImmutableMap.Builder<String, String>(5)

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -462,8 +462,8 @@ public class M3ReporterTest {
 
         List<Metric> metrics;
 
-        try (final M3Reporter reporter = reporterBuilder.build()) {
-            try (final MockM3Server server = new MockM3Server(expectedMetricsCount, socketAddress)) {
+        try (final MockM3Server server =bootM3Collector(expectedMetricsCount)) {
+            try (final M3Reporter reporter = reporterBuilder.build()) {
 
                 ImmutableMap<String, String> emptyTags =
                         new ImmutableMap.Builder<String, String>(0).build();
@@ -475,14 +475,15 @@ public class M3ReporterTest {
                     reporter.reportCounter("c", emptyTags, 1);
                 }
 
-                // Shutdown both reporter and server
+                // Shutdown reporter
                 reporter.close();
+
                 server.await();
 
                 metrics = server.getService().getMetrics();
             }
         }
 
-        assertEquals(metrics.size(), expectedMetricsCount);
+        assertEquals(expectedMetricsCount, metrics.size());
     }
 }

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -71,7 +71,7 @@ public class M3ReporterTest {
 
     @Before
     public void setupTest() throws UnknownHostException {
-        socketAddress = new InetSocketAddress(InetAddress.getByName("localhost"), 12345);
+        socketAddress = new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 12345);
         reporter =
                 new M3Reporter.Builder(socketAddress)
                     .service("test-service")

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -114,6 +114,7 @@ public class M3ReporterTest {
                     .includeHost(true)
 
         List<MetricBatch> receivedBatches;
+        List<Metric> receivedMetrics;
 
         try (final M3Reporter reporter = reporterBuilder.build()) {
             try (final MockM3Server server = bootM3Collector(3)) {
@@ -131,10 +132,9 @@ public class M3ReporterTest {
                 server.await();
 
                 receivedBatches = server.getService().getBatches();
+                receivedMetrics = server.getService().getMetrics();
             }
         }
-
-        assertEquals(3, receivedBatches.size());
 
         // Validate common tags
         for (MetricBatch batch : receivedBatches) {
@@ -152,18 +152,11 @@ public class M3ReporterTest {
         }
 
         // Validate metrics
-        List<Metric> emittedCounters = receivedBatches.get(0).getMetrics();
-        assertEquals(1, emittedCounters.size());
+        assertEquals(3, receivedMetrics.size());
 
-        List<Metric> emittedTimers = receivedBatches.get(1).getMetrics();
-        assertEquals(1, emittedTimers.size());
-
-        List<Metric> emittedGauges = receivedBatches.get(2).getMetrics();
-        assertEquals(1, emittedGauges.size());
-
-        Metric emittedCounter = emittedCounters.get(0);
-        Metric emittedTimer = emittedTimers.get(0);
-        Metric emittedGauge = emittedGauges.get(0);
+        Metric emittedCounter = receivedMetrics.get(0);
+        Metric emittedTimer = receivedMetrics.get(1);
+        Metric emittedGauge = receivedMetrics.get(2);
 
         assertEquals("my-counter", emittedCounter.getName());
         assertTrue(emittedCounter.isSetTags());

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -344,7 +344,7 @@ public class M3ReporterTest {
     public void reporterHistogramValues() throws InterruptedException {
         List<MetricBatch> receivedBatches;
 
-        try(final MockM3Server server = bootM3Collector(2);) {
+        try (final MockM3Server server = bootM3Collector(2);) {
             Buckets buckets = ValueBuckets.linear(0, 25_000_000, 5);
 
             Map<String, String> histogramTags = new HashMap<>();
@@ -462,7 +462,7 @@ public class M3ReporterTest {
 
         List<Metric> metrics;
 
-        try (final MockM3Server server =bootM3Collector(expectedMetricsCount)) {
+        try (final MockM3Server server = bootM3Collector(expectedMetricsCount)) {
             try (final M3Reporter reporter = reporterBuilder.build()) {
 
                 ImmutableMap<String, String> emptyTags =

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -55,7 +55,7 @@ import static org.junit.Assert.assertTrue;
 // TODO add tests for multi-processor setup
 public class M3ReporterTest {
 
-    private static final java.time.Duration MAX_WAIT_TIMEOUT = java.time.Duration.ofSeconds(10);
+    private static final java.time.Duration MAX_WAIT_TIMEOUT = java.time.Duration.ofSeconds(30);
 
     private static double EPSILON = 1e-9;
 

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -33,6 +33,8 @@ import com.uber.m3.thrift.gen.MetricValue;
 import com.uber.m3.thrift.gen.TimerValue;
 import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -60,6 +62,8 @@ public class M3ReporterTest {
             "host", "test-host"
         );
 
+    private M3Reporter reporter;
+
     @BeforeClass
     public static void setup() {
         try {
@@ -69,22 +73,25 @@ public class M3ReporterTest {
         }
     }
 
+    @Before
+    public void setupTest() {
+        reporter =
+                new M3Reporter.Builder(socketAddress)
+                    .service("test-service")
+                    .commonTags(DEFAULT_TAGS)
+                    .maxQueueSize(MAX_QUEUE_SIZE)
+                    .maxPacketSizeBytes(MAX_PACKET_SIZE_BYTES)
+                    .build();
+    }
+
+    @After
+    public void teardownTest() {
+        reporter.close();
+    }
+
     @Test
     public void reporter() throws InterruptedException {
-        final MockM3Server server = new MockM3Server(3, socketAddress);
-        M3Reporter reporter = null;
-
-        Thread serverThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                server.serve();
-            }
-        });
-
-        try {
-            serverThread.start();
-
-            ImmutableMap<String, String> commonTags = new ImmutableMap.Builder<String, String>(5)
+        ImmutableMap<String, String> commonTags = new ImmutableMap.Builder<String, String>(5)
                 .put("env", "development")
                 .put("host", "default")
                 .put("commonTag1", "val1")
@@ -92,112 +99,112 @@ public class M3ReporterTest {
                 .put("commonTag3", "val3")
                 .build();
 
-            reporter = new M3Reporter.Builder(socketAddress)
-                .service("test-service")
-                .commonTags(commonTags)
-                .includeHost(true)
-                .build();
-
-            ImmutableMap<String, String> tags = new ImmutableMap.Builder<String, String>(2)
+        ImmutableMap<String, String> tags = new ImmutableMap.Builder<String, String>(2)
                 .put("testTag1", "testVal1")
                 .put("testTag2", "testVal2")
                 .build();
 
-            reporter.reportCounter("my-counter", tags, 10);
-            reporter.flush();
+        M3Reporter.Builder reporterBuilder =
+                new M3Reporter.Builder(socketAddress)
+                    .service("test-service")
+                    .commonTags(commonTags)
+                    .includeHost(true)
 
-            reporter.reportTimer("my-timer", tags, Duration.ofMillis(5));
-            reporter.flush();
+        List<MetricBatch> receivedBatches;
 
-            reporter.reportGauge("my-gauge", tags, 42.42);
-            reporter.flush();
+        try (final M3Reporter reporter = reporterBuilder.build()) {
+            try (final MockM3Server server = bootM3Collector(3)) {
+                reporter.reportCounter("my-counter", tags, 10);
+                reporter.flush();
 
-            // Shutdown both reporter and server
-            reporter.close();
-            server.awaitAndClose();
+                reporter.reportTimer("my-timer", tags, Duration.ofMillis(5));
+                reporter.flush();
 
-            List<MetricBatch> batches = server.getService().getBatches();
-            assertEquals(3, batches.size());
+                reporter.reportGauge("my-gauge", tags, 42.42);
+                reporter.flush();
 
-            // Validate common tags
-            for (MetricBatch batch : batches) {
-                assertNotNull(batch);
-                assertTrue(batch.isSetCommonTags());
-                assertEquals(commonTags.size() + 1, batch.getCommonTags().size());
+                // Shutdown both reporter and server
+                reporter.close();
+                server.await();
 
-                for (MetricTag tag : batch.getCommonTags()) {
-                    if (tag.getTagName().equals(M3Reporter.SERVICE_TAG)) {
-                        assertEquals("test-service", tag.getTagValue());
-                    } else {
-                        assertEquals(commonTags.get(tag.getTagName()), tag.getTagValue());
-                    }
+                receivedBatches = server.getService().getBatches();
+            }
+        }
+
+        assertEquals(3, receivedBatches.size());
+
+        // Validate common tags
+        for (MetricBatch batch : receivedBatches) {
+            assertNotNull(batch);
+            assertTrue(batch.isSetCommonTags());
+            assertEquals(commonTags.size() + 1, batch.getCommonTags().size());
+
+            for (MetricTag tag : batch.getCommonTags()) {
+                if (tag.getTagName().equals(M3Reporter.SERVICE_TAG)) {
+                    assertEquals("test-service", tag.getTagValue());
+                } else {
+                    assertEquals(commonTags.get(tag.getTagName()), tag.getTagValue());
                 }
             }
-
-            // Validate metrics
-            List<Metric> emittedCounters = batches.get(0).getMetrics();
-            assertEquals(1, emittedCounters.size());
-
-            List<Metric> emittedTimers = batches.get(1).getMetrics();
-            assertEquals(1, emittedTimers.size());
-
-            List<Metric> emittedGauges = batches.get(2).getMetrics();
-            assertEquals(1, emittedGauges.size());
-
-            Metric emittedCounter = emittedCounters.get(0);
-            Metric emittedTimer = emittedTimers.get(0);
-            Metric emittedGauge = emittedGauges.get(0);
-
-            assertEquals("my-counter", emittedCounter.getName());
-            assertTrue(emittedCounter.isSetTags());
-            assertEquals(tags.size(), emittedCounter.getTagsSize());
-
-            for (MetricTag tag : emittedCounter.getTags()) {
-                assertEquals(tags.get(tag.getTagName()), tag.getTagValue());
-            }
-
-            // Validate counter
-            assertTrue(emittedCounter.isSetMetricValue());
-
-            MetricValue emittedValue = emittedCounter.getMetricValue();
-            assertTrue(emittedValue.isSetCount());
-            assertFalse(emittedValue.isSetGauge());
-            assertFalse(emittedValue.isSetTimer());
-
-            CountValue emittedCount = emittedValue.getCount();
-            assertTrue(emittedCount.isSetI64Value());
-            assertEquals(10, emittedCount.getI64Value());
-
-            // Validate timer
-            assertTrue(emittedTimer.isSetMetricValue());
-
-            emittedValue = emittedTimer.getMetricValue();
-            assertFalse(emittedValue.isSetCount());
-            assertFalse(emittedValue.isSetGauge());
-            assertTrue(emittedValue.isSetTimer());
-
-            TimerValue emittedTimerValue = emittedValue.getTimer();
-            assertTrue(emittedTimerValue.isSetI64Value());
-            assertEquals(5_000_000, emittedTimerValue.getI64Value());
-
-            // Validate gauge
-            assertTrue(emittedGauge.isSetMetricValue());
-
-            emittedValue = emittedGauge.getMetricValue();
-            assertFalse(emittedValue.isSetCount());
-            assertTrue(emittedValue.isSetGauge());
-            assertFalse(emittedValue.isSetTimer());
-
-            GaugeValue emittedGaugeValue = emittedValue.getGauge();
-            assertTrue(emittedGaugeValue.isSetDValue());
-            assertEquals(42.42, emittedGaugeValue.getDValue(), EPSILON);
-        } finally {
-            if (reporter != null) {
-                reporter.close();
-            }
-
-            server.awaitAndClose();
         }
+
+        // Validate metrics
+        List<Metric> emittedCounters = receivedBatches.get(0).getMetrics();
+        assertEquals(1, emittedCounters.size());
+
+        List<Metric> emittedTimers = receivedBatches.get(1).getMetrics();
+        assertEquals(1, emittedTimers.size());
+
+        List<Metric> emittedGauges = receivedBatches.get(2).getMetrics();
+        assertEquals(1, emittedGauges.size());
+
+        Metric emittedCounter = emittedCounters.get(0);
+        Metric emittedTimer = emittedTimers.get(0);
+        Metric emittedGauge = emittedGauges.get(0);
+
+        assertEquals("my-counter", emittedCounter.getName());
+        assertTrue(emittedCounter.isSetTags());
+        assertEquals(tags.size(), emittedCounter.getTagsSize());
+
+        for (MetricTag tag : emittedCounter.getTags()) {
+            assertEquals(tags.get(tag.getTagName()), tag.getTagValue());
+        }
+
+        // Validate counter
+        assertTrue(emittedCounter.isSetMetricValue());
+
+        MetricValue emittedValue = emittedCounter.getMetricValue();
+        assertTrue(emittedValue.isSetCount());
+        assertFalse(emittedValue.isSetGauge());
+        assertFalse(emittedValue.isSetTimer());
+
+        CountValue emittedCount = emittedValue.getCount();
+        assertTrue(emittedCount.isSetI64Value());
+        assertEquals(10, emittedCount.getI64Value());
+
+        // Validate timer
+        assertTrue(emittedTimer.isSetMetricValue());
+
+        emittedValue = emittedTimer.getMetricValue();
+        assertFalse(emittedValue.isSetCount());
+        assertFalse(emittedValue.isSetGauge());
+        assertTrue(emittedValue.isSetTimer());
+
+        TimerValue emittedTimerValue = emittedValue.getTimer();
+        assertTrue(emittedTimerValue.isSetI64Value());
+        assertEquals(5_000_000, emittedTimerValue.getI64Value());
+
+        // Validate gauge
+        assertTrue(emittedGauge.isSetMetricValue());
+
+        emittedValue = emittedGauge.getMetricValue();
+        assertFalse(emittedValue.isSetCount());
+        assertTrue(emittedValue.isSetGauge());
+        assertFalse(emittedValue.isSetTimer());
+
+        GaugeValue emittedGaugeValue = emittedValue.getGauge();
+        assertTrue(emittedGaugeValue.isSetDValue());
+        assertEquals(42.42, emittedGaugeValue.getDValue(), EPSILON);
     }
 
     @Test
@@ -229,112 +236,69 @@ public class M3ReporterTest {
 
     @Test
     public void reporterFinalFlush() throws InterruptedException {
-        final MockM3Server server = new MockM3Server(1, socketAddress);
+        try (final MockM3Server server = bootM3Collector(1)) {
+            reporter.reportTimer("final-flush-timer", null, Duration.ofMillis(10));
+            reporter.close();
 
-        Thread serverThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                server.serve();
-            }
-        });
+            server.await();
 
-        serverThread.start();
-
-        M3Reporter reporter = new M3Reporter.Builder(socketAddress)
-            .service("test-service")
-            .commonTags(DEFAULT_TAGS)
-            .build();
-
-        reporter.reportTimer("final-flush-timer", null, Duration.ofMillis(10));
-
-        reporter.close();
-        server.awaitAndClose();
-
-        List<MetricBatch> batches = server.getService().getBatches();
-        assertEquals(1, batches.size());
-        assertNotNull(batches.get(0));
-        assertEquals(1, batches.get(0).getMetrics().size());
+            List<MetricBatch> batches = server.getService().getBatches();
+            assertEquals(1, batches.size());
+            assertNotNull(batches.get(0));
+            assertEquals(1, batches.get(0).getMetrics().size());
+        }
     }
 
     @Test
     public void reporterAfterCloseNoThrow() throws InterruptedException {
-        final MockM3Server server = new MockM3Server(0, socketAddress);
-
-        Thread serverThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                server.serve();
-            }
-        });
-
-        try {
-            serverThread.start();
-
-            M3Reporter reporter = new M3Reporter.Builder(socketAddress)
-                .service("test-service")
-                .commonTags(DEFAULT_TAGS)
-                .build();
-
+        try (final MockM3Server server = bootM3Collector(0);) {
             reporter.close();
 
             reporter.reportGauge("my-gauge", null, 4.2);
             reporter.flush();
-        } finally {
-            server.awaitAndClose();
         }
     }
 
     @Test
     public void reporterHistogramDurations() throws InterruptedException {
-        final MockM3Server server = new MockM3Server(2, socketAddress);
+        List<MetricBatch> receivedBatches;
 
-        Thread serverThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                server.serve();
-            }
-        });
+        try (final MockM3Server server = bootM3Collector(2)) {
+            Buckets buckets = DurationBuckets.linear(Duration.ZERO, Duration.ofMillis(25), 5);
 
-        serverThread.start();
+            Map<String, String> histogramTags = new HashMap<>();
+            histogramTags.put("foo", "bar");
 
-        M3Reporter reporter = new M3Reporter.Builder(socketAddress)
-            .service("test-service")
-            .commonTags(DEFAULT_TAGS)
-            .build();
+            reporter.reportHistogramDurationSamples(
+                    "my-histogram",
+                    histogramTags,
+                    buckets,
+                    Duration.ZERO,
+                    Duration.ofMillis(25),
+                    7
+            );
 
-        Buckets buckets = DurationBuckets.linear(Duration.ZERO, Duration.ofMillis(25), 5);
+            reporter.reportHistogramDurationSamples(
+                    "my-histogram",
+                    histogramTags,
+                    buckets,
+                    Duration.ofMillis(50),
+                    Duration.ofMillis(75),
+                    3
+            );
 
-        Map<String, String> histogramTags = new HashMap<>();
-        histogramTags.put("foo", "bar");
+            reporter.close();
+            server.await();
 
-        reporter.reportHistogramDurationSamples(
-            "my-histogram",
-            histogramTags,
-            buckets,
-            Duration.ZERO,
-            Duration.ofMillis(25),
-            7
-        );
+            receivedBatches = server.getService().getBatches();
+        }
 
-        reporter.reportHistogramDurationSamples(
-            "my-histogram",
-            histogramTags,
-            buckets,
-            Duration.ofMillis(50),
-            Duration.ofMillis(75),
-            3
-        );
-
-        reporter.close();
-        server.awaitAndClose();
-
-        List<MetricBatch> batches = server.getService().getBatches();
-        assertEquals(1, batches.size());
-        assertNotNull(batches.get(0));
-        assertEquals(2, batches.get(0).getMetrics().size());
+        assertEquals(1, receivedBatches.size());
+        assertNotNull(receivedBatches.get(0));
+        assertEquals(2, receivedBatches.get(0).getMetrics().size());
 
         // Verify first bucket
-        Metric metric = batches.get(0).getMetrics().get(0);
+        Metric metric = receivedBatches.get(0).getMetrics().get(0);
         assertEquals("my-histogram", metric.getName());
         assertTrue(metric.isSetTags());
         assertEquals(3, metric.getTagsSize());
@@ -359,7 +323,7 @@ public class M3ReporterTest {
         assertEquals(7, count.getI64Value());
 
         // Verify second bucket
-        metric = server.getService().getBatches().get(0).getMetrics().get(1);
+        metric = receivedBatches.get(0).getMetrics().get(1);
         assertEquals("my-histogram", metric.getName());
         assertTrue(metric.isSetTags());
         assertEquals(3, metric.getTagsSize());
@@ -384,104 +348,89 @@ public class M3ReporterTest {
 
     @Test
     public void reporterHistogramValues() throws InterruptedException {
-        final MockM3Server server = new MockM3Server(2, socketAddress);
+        List<MetricBatch> receivedBatches;
 
-        Thread serverThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                server.serve();
-            }
-        });
-
-        try {
-            serverThread.start();
-
-            M3Reporter reporter = new M3Reporter.Builder(socketAddress)
-                .service("test-service")
-                .commonTags(DEFAULT_TAGS)
-                .build();
-
+        try(final MockM3Server server = bootM3Collector(2);) {
             Buckets buckets = ValueBuckets.linear(0, 25_000_000, 5);
 
             Map<String, String> histogramTags = new HashMap<>();
             histogramTags.put("foo", "bar");
 
             reporter.reportHistogramValueSamples(
-                "my-histogram",
-                histogramTags,
-                buckets,
-                0,
-                25_000_000,
-                7
+                    "my-histogram",
+                    histogramTags,
+                    buckets,
+                    0,
+                    25_000_000,
+                    7
             );
 
             reporter.reportHistogramValueSamples(
-                "my-histogram",
-                histogramTags,
-                buckets,
-                50_000_000,
-                75_000_000,
-                3
+                    "my-histogram",
+                    histogramTags,
+                    buckets,
+                    50_000_000,
+                    75_000_000,
+                    3
             );
 
             reporter.close();
-            server.awaitAndClose();
+            server.await();
 
-            List<MetricBatch> batches = server.getService().getBatches();
-            assertEquals(1, batches.size());
-            assertNotNull(batches.get(0));
-            assertEquals(2, batches.get(0).getMetrics().size());
-
-            // Verify first bucket
-            Metric metric = batches.get(0).getMetrics().get(0);
-            assertEquals("my-histogram", metric.getName());
-            assertTrue(metric.isSetTags());
-            assertEquals(3, metric.getTagsSize());
-
-            Map<String, String> expectedTags = new HashMap<>(3, 1);
-            expectedTags.put("foo", "bar");
-            expectedTags.put("bucketid", "0001");
-            expectedTags.put("bucket", "0.000000-25000000.000000");
-            for (MetricTag tag : metric.getTags()) {
-                assertEquals(expectedTags.get(tag.getTagName()), tag.getTagValue());
-            }
-
-            assertTrue(metric.isSetMetricValue());
-
-            MetricValue value = metric.getMetricValue();
-            assertTrue(value.isSetCount());
-            assertFalse(value.isSetGauge());
-            assertFalse(value.isSetTimer());
-
-            CountValue count = value.getCount();
-            assertTrue(count.isSetI64Value());
-            assertEquals(7, count.getI64Value());
-
-            // Verify second bucket
-            metric = server.getService().getBatches().get(0).getMetrics().get(1);
-            assertEquals("my-histogram", metric.getName());
-            assertTrue(metric.isSetTags());
-            assertEquals(3, metric.getTagsSize());
-
-            expectedTags.put("bucketid", "0003");
-            expectedTags.put("bucket", "50000000.000000-75000000.000000");
-            for (MetricTag tag : metric.getTags()) {
-                assertEquals(expectedTags.get(tag.getTagName()), tag.getTagValue());
-            }
-
-            assertTrue(metric.isSetMetricValue());
-
-            value = metric.getMetricValue();
-            assertTrue(value.isSetCount());
-            assertFalse(value.isSetGauge());
-            assertFalse(value.isSetTimer());
-
-            count = value.getCount();
-            assertTrue(count.isSetI64Value());
-            assertEquals(3, count.getI64Value());
-        } finally {
-            server.awaitAndClose();
+            receivedBatches = server.getService().getBatches();
         }
+
+        assertEquals(1, receivedBatches.size());
+        assertNotNull(receivedBatches.get(0));
+        assertEquals(2, receivedBatches.get(0).getMetrics().size());
+
+        // Verify first bucket
+        Metric metric = receivedBatches.get(0).getMetrics().get(0);
+        assertEquals("my-histogram", metric.getName());
+        assertTrue(metric.isSetTags());
+        assertEquals(3, metric.getTagsSize());
+
+        Map<String, String> expectedTags = new HashMap<>(3, 1);
+        expectedTags.put("foo", "bar");
+        expectedTags.put("bucketid", "0001");
+        expectedTags.put("bucket", "0.000000-25000000.000000");
+        for (MetricTag tag : metric.getTags()) {
+            assertEquals(expectedTags.get(tag.getTagName()), tag.getTagValue());
+        }
+
+        assertTrue(metric.isSetMetricValue());
+
+        MetricValue value = metric.getMetricValue();
+        assertTrue(value.isSetCount());
+        assertFalse(value.isSetGauge());
+        assertFalse(value.isSetTimer());
+
+        CountValue count = value.getCount();
+        assertTrue(count.isSetI64Value());
+        assertEquals(7, count.getI64Value());
+
+        // Verify second bucket
+        metric = receivedBatches.get(0).getMetrics().get(1);
+        assertEquals("my-histogram", metric.getName());
+        assertTrue(metric.isSetTags());
+        assertEquals(3, metric.getTagsSize());
+
+        expectedTags.put("bucketid", "0003");
+        expectedTags.put("bucket", "50000000.000000-75000000.000000");
+        for (MetricTag tag : metric.getTags()) {
+            assertEquals(expectedTags.get(tag.getTagName()), tag.getTagValue());
+        }
+
+        assertTrue(metric.isSetMetricValue());
+
+        value = metric.getMetricValue();
+        assertTrue(value.isSetCount());
+        assertFalse(value.isSetGauge());
+        assertFalse(value.isSetTimer());
+
+        count = value.getCount();
+        assertTrue(count.isSetI64Value());
+        assertEquals(3, count.getI64Value());
     }
 
     @Test
@@ -492,6 +441,12 @@ public class M3ReporterTest {
             .build();
 
         assertEquals(CapableOf.REPORTING_TAGGING, reporter.capabilities());
+    }
+
+    private static MockM3Server bootM3Collector(int expectedMetricsCount) {
+        final MockM3Server server = new MockM3Server(expectedMetricsCount, socketAddress);
+        new Thread(server::serve).start();
+        return server;
     }
 
     @Test

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -51,6 +51,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+// TODO add tests to validate proper shutdown
+// TODO add tests to validate uncaughts don't crash processor
+// TODO add tests for multi-processor setup
 public class M3ReporterTest {
     private static double EPSILON = 1e-9;
 

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Server.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Server.java
@@ -36,7 +36,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class MockM3Server implements AutoCloseable {
-    private static final Duration MAX_WAIT_TIMEOUT = Duration.ofMinutes(1);
     private final CountDownLatch expectedMetricsLatch;
 
     private final TProcessor processor;
@@ -89,8 +88,8 @@ public class MockM3Server implements AutoCloseable {
      *
      * @throws InterruptedException
      */
-    public void await() throws InterruptedException {
-        expectedMetricsLatch.await(MAX_WAIT_TIMEOUT.getSeconds(), TimeUnit.SECONDS);
+    public void await(Duration waitTimeout) throws InterruptedException {
+        expectedMetricsLatch.await(waitTimeout.getSeconds(), TimeUnit.SECONDS);
     }
 
     @Override

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Server.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Server.java
@@ -35,14 +35,13 @@ import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-public class MockM3Server {
+public class MockM3Server implements AutoCloseable {
     private static final Duration MAX_WAIT_TIMEOUT = Duration.ofSeconds(30);
-
     private final CountDownLatch expectedMetricsLatch;
 
-    private TProcessor processor;
-    private TTransport transport;
-    private MockM3Service service;
+    private final TProcessor processor;
+    private final TTransport transport;
+    private final MockM3Service service;
 
     public MockM3Server(
         int expectedMetricsCount,
@@ -81,12 +80,22 @@ public class MockM3Server {
         }
     }
 
-    public void awaitAndClose() throws InterruptedException {
-        expectedMetricsLatch.await(MAX_WAIT_TIMEOUT.getSeconds(), TimeUnit.SECONDS);
-        transport.close();
-    }
-
     public MockM3Service getService() {
         return service;
+    }
+
+    /**
+     * Awaits receiving of all the expected metrics
+     *
+     * @throws InterruptedException
+     */
+    public void await() throws InterruptedException {
+        expectedMetricsLatch.await(MAX_WAIT_TIMEOUT.getSeconds(), TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void close() {
+        // Close immediately without waiting
+        transport.close();
     }
 }

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Server.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Server.java
@@ -36,7 +36,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class MockM3Server implements AutoCloseable {
-    private static final Duration MAX_WAIT_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration MAX_WAIT_TIMEOUT = Duration.ofMinutes(1);
     private final CountDownLatch expectedMetricsLatch;
 
     private final TProcessor processor;

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Server.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Server.java
@@ -28,6 +28,8 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
 import java.net.SocketException;
@@ -36,6 +38,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 public class MockM3Server implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MockM3Server.class);
+
     private final CountDownLatch expectedMetricsLatch;
 
     private final TProcessor processor;
@@ -60,6 +65,8 @@ public class MockM3Server implements AutoCloseable {
     public void serve() {
         try {
             transport.open();
+
+            LOG.info("Opened receiving server socket");
         } catch (TTransportException e) {
             throw new RuntimeException("Failed to open socket", e);
         }
@@ -96,5 +103,7 @@ public class MockM3Server implements AutoCloseable {
     public void close() {
         // Close immediately without waiting
         transport.close();
+
+        LOG.info("Closing receiving server socket");
     }
 }

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
@@ -40,10 +40,10 @@ public class MockM3Service implements M3.Iface {
         this.metricsCountLatch = metricsCountLatch;
     }
 
-    public List<MetricBatch> getBatches() {
+    public List<MetricBatch> snapshotBatches() {
         lock.readLock().lock();
         try {
-            return batches;
+            return new ArrayList<>(batches);
         } finally {
             lock.readLock().unlock();
         }

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
@@ -48,10 +48,10 @@ public class MockM3Service implements M3.Iface {
             lock.readLock().unlock();
         }
     }
-    public List<Metric> getMetrics() {
+    public List<Metric> snapshotMetrics() {
         lock.readLock().lock();
         try {
-            return metrics;
+            return new ArrayList<>(metrics);
         } finally {
             lock.readLock().unlock();
         }

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
@@ -23,7 +23,6 @@ package com.uber.m3.tally.m3;
 import com.uber.m3.thrift.gen.M3;
 import com.uber.m3.thrift.gen.Metric;
 import com.uber.m3.thrift.gen.MetricBatch;
-import org.apache.thrift.transport.TTransportException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,16 +42,23 @@ public class MockM3Service implements M3.Iface {
 
     public List<MetricBatch> getBatches() {
         lock.readLock().lock();
-
         try {
             return batches;
         } finally {
             lock.readLock().unlock();
         }
     }
+    public List<Metric> getMetrics() {
+        lock.readLock().lock();
+        try {
+            return metrics;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
 
     @Override
-    public void emitMetricBatch(MetricBatch batch) throws TTransportException {
+    public void emitMetricBatch(MetricBatch batch) {
         lock.writeLock().lock();
 
         batches.add(batch);

--- a/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/MockM3Service.java
@@ -59,7 +59,6 @@ public class MockM3Service implements M3.Iface {
 
         for (Metric metric : batch.getMetrics()) {
             metrics.add(metric);
-
             metricsCountLatch.countDown();
         }
 


### PR DESCRIPTION
Fixing `M3Reporter.Processor` preparing it for multi-processor setup.

Previously even though `M3Reporter` had been setup to run 10 Processors, it never actually worked properly and by pure luck it wasn't actually corrupting its own state (due to those errors somewhat saving it from it): 

1. Flushing sequence didn't work: flush was only triggered within a single processor
2. Processors were sharing the same transport without ANY synchronization which might potentially end up in corrupted payload being sent over the wire

This change addresses all of those issues.

However, additional tests needs to be written along with current existing fixed.