### PR TITLE
Refactored Histogram impl to avoid CPU churn

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -40,18 +40,3 @@ task jmh(type: JavaExec, dependsOn: jmhClasses) {
 }
 
 classes.finalizedBy(jmhClasses)
-
-//jmh {
-//    benchmarkMode = ['Throughput']
-//
-//    warmupIterations = 5
-//
-//    iterations = 5
-//    batchSize = 1
-//
-//    fork = 1
-//    forceGC = true
-//    includeTests = true
-//
-//    duplicateClassesStrategy = 'warn'
-//}

--- a/core/src/jmh/java/com/uber/m3/tally/ScopeImplBenchmark.java
+++ b/core/src/jmh/java/com/uber/m3/tally/ScopeImplBenchmark.java
@@ -116,4 +116,9 @@ public class ScopeImplBenchmark {
         }
 
     }
+
+    @Benchmark
+    public void scopeReportingBenchmark(BenchmarkState state) {
+        state.scope.reportLoopIteration();
+    }
 }

--- a/core/src/jmh/java/com/uber/m3/tally/ScopeImplBenchmark.java
+++ b/core/src/jmh/java/com/uber/m3/tally/ScopeImplBenchmark.java
@@ -116,9 +116,4 @@ public class ScopeImplBenchmark {
         }
 
     }
-
-    @Benchmark
-    public void scopeReportingBenchmark(BenchmarkState state) {
-        state.scope.reportLoopIteration();
-    }
 }

--- a/core/src/main/java/com/uber/m3/tally/BucketPairImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/BucketPairImpl.java
@@ -26,7 +26,10 @@ import java.util.Collections;
 
 /**
  * Default implementation of a {@link BucketPair}
+ *
+ * @deprecated will be removed
  */
+@Deprecated
 public class BucketPairImpl implements BucketPair {
     private double lowerBoundValue;
     private double upperBoundValue;

--- a/core/src/main/java/com/uber/m3/tally/GaugeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/GaugeImpl.java
@@ -28,12 +28,14 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * Default implementation of a {@link Gauge}.
  */
-class GaugeImpl extends MetricBase implements Gauge {
+class GaugeImpl extends MetricBase implements Gauge, Reportable {
     private AtomicBoolean updated = new AtomicBoolean(false);
     private AtomicLong curr = new AtomicLong(0);
 
-    protected GaugeImpl(String fqn) {
+    protected GaugeImpl(ScopeImpl scope, String fqn) {
         super(fqn);
+
+        scope.addToReportingQueue(this);
     }
 
     @Override
@@ -42,18 +44,14 @@ class GaugeImpl extends MetricBase implements Gauge {
         updated.set(true);
     }
 
-    @Override
-    public String getQualifiedName() {
-        return super.getQualifiedName();
-    }
-
     double value() {
         return Double.longBitsToDouble(curr.get());
     }
 
-    void report(String name, ImmutableMap<String, String> tags, StatsReporter reporter) {
+    @Override
+    public void report(ImmutableMap<String, String> tags, StatsReporter reporter) {
         if (updated.getAndSet(false)) {
-            reporter.reportGauge(name, tags, value());
+            reporter.reportGauge(getQualifiedName(), tags, value());
         }
     }
 

--- a/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
@@ -96,7 +96,8 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
                 return bucketCounters[index];
             }
 
-            return (bucketCounters[index] = new HistogramBucketCounterImpl(scope, getQualifiedName(), index));
+            bucketCounters[index] = new HistogramBucketCounterImpl(scope, getQualifiedName(), index);
+            return bucketCounters[index];
         }
     }
 
@@ -172,7 +173,6 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
         }
 
         Map<Duration, Long> durations = new HashMap<>(bucketCounters.length, 1);
-
 
         for (int i = 0; i < bucketCounters.length; ++i) {
             durations.put(getUpperBoundDurationForBucket(i), getCounterValue(i));

--- a/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
@@ -113,7 +113,7 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
         // that the binary search is performed over upper bounds, if binary
         // search found the exact match we need to shift it by 1 to index appropriate bucket in the
         // array of (bucket's) counters
-        if (binarySearchResult > 0) {
+        if (binarySearchResult >= 0) {
             return binarySearchResult + 1;
         }
 

--- a/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
@@ -90,9 +90,8 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
         }
 
         // To maintain lock granularity we synchronize only on a
-        // particular bucket leveraging bucket's bound object
-        // TODO remove
-        synchronized (this) {
+        // particular bucket leveraging bucket's boundary as a sync target
+        synchronized (lookupByDuration[Math.min(index, lookupByDuration.length - 1)]) {
             // Check whether bucket has been already set,
             // while we were waiting for lock
             if (bucketCounters[index] != null) {

--- a/core/src/main/java/com/uber/m3/tally/MetricBase.java
+++ b/core/src/main/java/com/uber/m3/tally/MetricBase.java
@@ -20,8 +20,6 @@
 
 package com.uber.m3.tally;
 
-import com.uber.m3.util.ImmutableMap;
-
 abstract class MetricBase {
 
     private final String fullyQualifiedName;
@@ -30,9 +28,8 @@ abstract class MetricBase {
         this.fullyQualifiedName = fqn;
     }
 
-    String getQualifiedName() {
+    final String getQualifiedName() {
         return fullyQualifiedName;
     }
 
-    abstract void report(String name, ImmutableMap<String, String> tags, StatsReporter reporter);
 }

--- a/core/src/main/java/com/uber/m3/tally/MetricBase.java
+++ b/core/src/main/java/com/uber/m3/tally/MetricBase.java
@@ -20,6 +20,9 @@
 
 package com.uber.m3.tally;
 
+/**
+ * Abstract common logic among every metric ({@link Counter}, {@link Gauge}, {@link Histogram})
+ */
 abstract class MetricBase {
 
     private final String fullyQualifiedName;

--- a/core/src/main/java/com/uber/m3/tally/Reportable.java
+++ b/core/src/main/java/com/uber/m3/tally/Reportable.java
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package com.uber.m3.tally;
 
 import com.uber.m3.util.ImmutableMap;

--- a/core/src/main/java/com/uber/m3/tally/Reportable.java
+++ b/core/src/main/java/com/uber/m3/tally/Reportable.java
@@ -2,6 +2,9 @@ package com.uber.m3.tally;
 
 import com.uber.m3.util.ImmutableMap;
 
+/**
+ * Abstracts capability to report the metrics to {@link StatsReporter}
+ */
 interface Reportable {
 
     void report(ImmutableMap<String, String> tags, StatsReporter reporter);

--- a/core/src/main/java/com/uber/m3/tally/Reportable.java
+++ b/core/src/main/java/com/uber/m3/tally/Reportable.java
@@ -1,0 +1,9 @@
+package com.uber.m3.tally;
+
+import com.uber.m3.util.ImmutableMap;
+
+interface Reportable {
+
+    void report(ImmutableMap<String, String> tags, StatsReporter reporter);
+
+}

--- a/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
@@ -89,7 +89,7 @@ class ScopeImpl implements Scope {
     public Histogram histogram(String name, Buckets buckets) {
         return histograms.computeIfAbsent(name, ignored ->
                 // NOTE: This will called at most once
-                addToReportingQueue(new HistogramImpl(fullyQualifiedName(name), tags, buckets)));
+                new HistogramImpl(this, fullyQualifiedName(name), tags, buckets));
     }
 
     @Override

--- a/core/src/test/java/com/uber/m3/tally/CounterImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/CounterImplTest.java
@@ -38,7 +38,7 @@ public class CounterImplTest {
                 .reporter(reporter)
                 .build();
 
-        counter = new CounterImpl(scope,"counter");
+        counter = new CounterImpl(scope, "counter");
     }
 
     @Test

--- a/core/src/test/java/com/uber/m3/tally/CounterImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/CounterImplTest.java
@@ -28,35 +28,41 @@ import static org.junit.Assert.assertEquals;
 public class CounterImplTest {
     private TestStatsReporter reporter;
     private CounterImpl counter;
+    private ScopeImpl scope;
 
     @Before
     public void setUp() {
         reporter = new TestStatsReporter();
-        counter = new CounterImpl("counter");
+        scope =
+            new ScopeBuilder(null, new ScopeImpl.Registry())
+                .reporter(reporter)
+                .build();
+
+        counter = new CounterImpl(scope,"counter");
     }
 
     @Test
     public void inc() {
         counter.inc(1);
-        counter.report("", null, reporter);
+        counter.report(null, reporter);
         assertEquals(1, reporter.nextCounterVal());
 
         counter.inc(1);
-        counter.report("", null, reporter);
+        counter.report(null, reporter);
         assertEquals(1, reporter.nextCounterVal());
 
         counter.inc(1);
         counter.inc(1);
-        counter.report("", null, reporter);
+        counter.report(null, reporter);
         assertEquals(2, reporter.nextCounterVal());
 
         counter.inc(3);
-        counter.report("", null, reporter);
+        counter.report(null, reporter);
         assertEquals(3, reporter.nextCounterVal());
 
         counter.inc(1);
         counter.inc(-3);
-        counter.report("", null, reporter);
+        counter.report(null, reporter);
         assertEquals(-2, reporter.nextCounterVal());
     }
 

--- a/core/src/test/java/com/uber/m3/tally/GaugeImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/GaugeImplTest.java
@@ -31,30 +31,37 @@ public class GaugeImplTest {
     private TestStatsReporter reporter;
     private GaugeImpl gauge;
 
+    private ScopeImpl scope;
+
     @Before
     public void setUp() {
         reporter = new TestStatsReporter();
-        gauge = new GaugeImpl("gauge");
+        scope =
+            new ScopeBuilder(null, new ScopeImpl.Registry())
+                .reporter(reporter)
+                .build();
+
+        gauge = new GaugeImpl(scope,"gauge");
     }
 
     @Test
     public void update() {
         gauge.update(42);
-        gauge.report("", null, reporter);
+        gauge.report(null, reporter);
         assertEquals(42, reporter.nextGaugeVal(), EPSILON);
 
         gauge.update(2);
         gauge.update(8);
-        gauge.report("", null, reporter);
+        gauge.report(null, reporter);
         assertEquals(8, reporter.nextGaugeVal(), EPSILON);
 
         gauge.update(0);
-        gauge.report("", null, reporter);
+        gauge.report(null, reporter);
         assertEquals(0, reporter.nextGaugeVal(), EPSILON);
 
         gauge.update(1);
         gauge.update(-3);
-        gauge.report("", null, reporter);
+        gauge.report(null, reporter);
         assertEquals(-3, reporter.nextGaugeVal(), EPSILON);
     }
 

--- a/core/src/test/java/com/uber/m3/tally/GaugeImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/GaugeImplTest.java
@@ -41,7 +41,7 @@ public class GaugeImplTest {
                 .reporter(reporter)
                 .build();
 
-        gauge = new GaugeImpl(scope,"gauge");
+        gauge = new GaugeImpl(scope, "gauge");
     }
 
     @Test


### PR DESCRIPTION
This is a follow-up for #73 to further reduce CPU churn by avoiding traversing empty arrays, and instead lazily subscribing individual buckets for reporting into enclosing scope.

```
# JMH version: 1.23
# VM version: JDK 1.8.0_242, OpenJDK 64-Bit Server VM, 25.242-b08
# VM invoker: /Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/bin/java
# VM options: -Dfile.encoding=UTF-8 -Duser.country=US -Duser.language=en -Duser.variant -server -XX:+UseG1GC
# Warmup: 5 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Throughput, ops/time
# Benchmark: com.uber.m3.tally.ScopeImplBenchmark.scopeReportingBenchmark

# Pre refactoring 
# 10% of buckets utilized 

Benchmark                                    Mode  Cnt    Score   Error   Units
ScopeImplBenchmark.scopeReportingBenchmark  thrpt   10  465.752 ± 7.296  ops/ms

# 20% of buckets utilized 

Benchmark                                    Mode  Cnt    Score    Error   Units
ScopeImplBenchmark.scopeReportingBenchmark  thrpt   10  434.375 ± 26.114  ops/ms

# Post refactoring
# 10% of buckets utilized 

Benchmark                                    Mode  Cnt     Score    Error   Units
ScopeImplBenchmark.scopeReportingBenchmark  thrpt   10  1929.097 ± 23.396  ops/ms

# 20% of buckets occupied

Benchmark                                    Mode  Cnt     Score    Error   Units
ScopeImplBenchmark.scopeReportingBenchmark  thrpt   10  1107.498 ± 20.499  ops/ms
```