### PR TITLE
Refactored M3 reporting to remove any unnecessary allocations

### DIFF
--- a/core/src/main/java/com/uber/m3/tally/AbstractBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/AbstractBuckets.java
@@ -21,8 +21,8 @@
 package com.uber.m3.tally;
 
 import com.uber.m3.util.Duration;
+import com.uber.m3.util.ImmutableList;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -40,14 +40,10 @@ public abstract class AbstractBuckets<T> implements Buckets<T> {
 
     AbstractBuckets(T[] buckets) {
         if (buckets == null) {
-            this.buckets = new ArrayList<>();
-        } else {
-            this.buckets = new ArrayList<>(Arrays.asList(buckets));
+            throw new IllegalArgumentException("provided buckets could not be null");
         }
-    }
 
-    AbstractBuckets() {
-        this(null);
+        this.buckets = new ImmutableList<>(Arrays.asList(buckets));
     }
 
     @Override

--- a/core/src/main/java/com/uber/m3/tally/AbstractBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/AbstractBuckets.java
@@ -35,7 +35,7 @@ import java.util.ListIterator;
  * Please use {@link ImmutableBuckets} instead
  */
 @Deprecated
-public abstract class AbstractBuckets<T> implements Buckets<T> {
+public abstract class AbstractBuckets<T extends Comparable<T>> implements Buckets<T> {
     protected List<T> buckets;
 
     AbstractBuckets(T[] buckets) {
@@ -43,7 +43,17 @@ public abstract class AbstractBuckets<T> implements Buckets<T> {
             throw new IllegalArgumentException("provided buckets could not be null");
         }
 
+        validate(buckets);
+
         this.buckets = new ImmutableList<>(Arrays.asList(buckets));
+    }
+
+    public void validate(T[] buckets) {
+        for (int i = 1; i < buckets.length; ++i) {
+            if (buckets[i - 1].compareTo(buckets[i]) > 0) {
+                throw new IllegalArgumentException("buckets should be in a non-decreasing order");
+            }
+        }
     }
 
     @Override

--- a/core/src/main/java/com/uber/m3/tally/AbstractBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/AbstractBuckets.java
@@ -30,8 +30,11 @@ import java.util.List;
 import java.util.ListIterator;
 
 /**
- * Abstract {@link Buckets} implementation for common functionality.
+ * @deprecated DO NOT USE
+ *
+ * Please use {@link ImmutableBuckets} instead
  */
+@Deprecated
 public abstract class AbstractBuckets<T> implements Buckets<T> {
     protected List<T> buckets;
 

--- a/core/src/main/java/com/uber/m3/tally/BucketPairImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/BucketPairImpl.java
@@ -60,8 +60,6 @@ public class BucketPairImpl implements BucketPair {
             };
         }
 
-        Collections.sort(buckets);
-
         Double[] asValueBuckets = buckets.asValues();
         Duration[] asDurationBuckets = buckets.asDurations();
         BucketPair[] pairs = new BucketPair[buckets.size() + 1];

--- a/core/src/main/java/com/uber/m3/tally/BucketPairImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/BucketPairImpl.java
@@ -22,8 +22,6 @@ package com.uber.m3.tally;
 
 import com.uber.m3.util.Duration;
 
-import java.util.Collections;
-
 /**
  * Default implementation of a {@link BucketPair}
  *

--- a/core/src/main/java/com/uber/m3/tally/BucketPairImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/BucketPairImpl.java
@@ -27,7 +27,7 @@ import java.util.Collections;
 /**
  * Default implementation of a {@link BucketPair}
  *
- * @deprecated will be removed
+ * @deprecated DO NOT USE, WILL BE REMOVED IN THE NEXT VERSION
  */
 @Deprecated
 public class BucketPairImpl implements BucketPair {

--- a/core/src/main/java/com/uber/m3/tally/Buckets.java
+++ b/core/src/main/java/com/uber/m3/tally/Buckets.java
@@ -40,6 +40,7 @@ public interface Buckets<E> extends ImmutableBuckets, List<E> {
     /**
      * @deprecated DO NOT USE
      */
+    @Deprecated
     Duration[] asDurations();
 
 }

--- a/core/src/main/java/com/uber/m3/tally/Buckets.java
+++ b/core/src/main/java/com/uber/m3/tally/Buckets.java
@@ -25,18 +25,21 @@ import com.uber.m3.util.Duration;
 import java.util.List;
 
 /**
- * Buckets of a {@link Histogram}.
+ * @deprecated DO NOT USE
+ *
+ * Please use {@link ImmutableBuckets} instead
  */
-public interface Buckets<E> extends List<E> {
+@Deprecated
+public interface Buckets<E> extends ImmutableBuckets, List<E> {
     /**
-     * Returns these buckets as {@code double}s.
-     * @return an array of {@code double}s representing these buckets
+     * @deprecated DO NOT USE
      */
+    @Deprecated
     Double[] asValues();
 
     /**
-     * Returns these buckets as {@link Duration}s.
-     * @return an array of {@link Duration}s representing these buckets
+     * @deprecated DO NOT USE
      */
     Duration[] asDurations();
+
 }

--- a/core/src/main/java/com/uber/m3/tally/DurationBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/DurationBuckets.java
@@ -34,10 +34,6 @@ public class DurationBuckets extends AbstractBuckets<Duration> {
         super(durations);
     }
 
-    public DurationBuckets() {
-        super();
-    }
-
     @Override
     public Duration getDurationLowerBoundFor(int bucketIndex) {
         return bucketIndex == 0 ? Duration.MIN_VALUE : buckets.get(bucketIndex - 1);

--- a/core/src/main/java/com/uber/m3/tally/DurationBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/DurationBuckets.java
@@ -22,10 +22,14 @@ package com.uber.m3.tally;
 
 import com.uber.m3.util.Duration;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * {@link Buckets} implementation backed by {@link Duration}s.
  */
 public class DurationBuckets extends AbstractBuckets<Duration> {
+
     public DurationBuckets(Duration[] durations) {
         super(durations);
     }
@@ -35,16 +39,64 @@ public class DurationBuckets extends AbstractBuckets<Duration> {
     }
 
     @Override
+    public Duration getDurationLowerBoundFor(int bucketIndex) {
+        return bucketIndex == 0 ? Duration.MIN_VALUE : buckets.get(bucketIndex - 1);
+    }
+
+    @Override
+    public Duration getDurationUpperBoundFor(int bucketIndex) {
+        return bucketIndex < buckets.size() ? buckets.get(bucketIndex) : Duration.MAX_VALUE;
+    }
+
+    @Override
+    public int getBucketIndexFor(Duration value) {
+        return HistogramImpl.toBucketIndex(Collections.binarySearch(buckets, value));
+    }
+
+    @Override
+    public List<Duration> getDurationBuckets() {
+        return Collections.unmodifiableList(buckets);
+    }
+
+    @Override
+    public double getValueLowerBoundFor(int bucketIndex) {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    @Override
+    public double getValueUpperBoundFor(int bucketIndex) {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    @Override
+    public int getBucketIndexFor(double value) {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    @Override
+    public List<Double> getValueBuckets() {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    /**
+     * @deprecated DO NOT USE
+     */
+    @Deprecated
+    @Override
     public Double[] asValues() {
         Double[] values = new Double[buckets.size()];
 
         for (int i = 0; i < values.length; i++) {
-            values[i] = buckets.get(i).getSeconds();
+            values[i] = buckets.get(i).getSeconds() * Duration.NANOS_PER_SECOND;
         }
 
         return values;
     }
 
+    /**
+     * @deprecated DO NOT USE
+     */
+    @Deprecated
     @Override
     public Duration[] asDurations() {
         return buckets.toArray(new Duration[buckets.size()]);

--- a/core/src/main/java/com/uber/m3/tally/DurationBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/DurationBuckets.java
@@ -50,7 +50,7 @@ public class DurationBuckets extends AbstractBuckets<Duration> {
     }
 
     @Override
-    public List<Duration> getDurationBuckets() {
+    public List<Duration> getDurationUpperBounds() {
         return Collections.unmodifiableList(buckets);
     }
 
@@ -70,7 +70,7 @@ public class DurationBuckets extends AbstractBuckets<Duration> {
     }
 
     @Override
-    public List<Double> getValueBuckets() {
+    public List<Double> getValueUpperBounds() {
         throw new UnsupportedOperationException("not supported");
     }
 

--- a/core/src/main/java/com/uber/m3/tally/DurationBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/DurationBuckets.java
@@ -87,7 +87,7 @@ public class DurationBuckets extends AbstractBuckets<Duration> {
         Double[] values = new Double[buckets.size()];
 
         for (int i = 0; i < values.length; i++) {
-            values[i] = buckets.get(i).getSeconds() * Duration.NANOS_PER_SECOND;
+            values[i] = buckets.get(i).getSeconds();
         }
 
         return values;

--- a/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
@@ -64,13 +64,13 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
 
     @Override
     public void recordValue(double value) {
-        int index = toBucketIndex(Collections.binarySearch(specification.getValueBuckets(), value));
+        int index = toBucketIndex(Collections.binarySearch(specification.getValueUpperBounds(), value));
         getOrCreateCounter(index).inc(1);
     }
 
     @Override
     public void recordDuration(Duration duration) {
-        int index = toBucketIndex(Collections.binarySearch(specification.getDurationBuckets(), duration));
+        int index = toBucketIndex(Collections.binarySearch(specification.getDurationUpperBounds(), duration));
         getOrCreateCounter(index).inc(1);
     }
 
@@ -81,8 +81,8 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
 
         List<?> bucketsBounds =
                 this.type == Type.VALUE
-                        ? specification.getValueBuckets()
-                        : specification.getDurationBuckets();
+                        ? specification.getValueUpperBounds()
+                        : specification.getDurationUpperBounds();
 
         // To maintain lock granularity we synchronize only on a
         // particular bucket leveraging bucket's boundary as a sync target
@@ -130,19 +130,19 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
     }
 
     private Duration getUpperBoundDurationForBucket(int bucketIndex) {
-        return bucketIndex < specification.getDurationBuckets().size() ? specification.getDurationBuckets().get(bucketIndex) : Duration.MAX_VALUE;
+        return bucketIndex < specification.getDurationUpperBounds().size() ? specification.getDurationUpperBounds().get(bucketIndex) : Duration.MAX_VALUE;
     }
 
     private Duration getLowerBoundDurationForBucket(int bucketIndex) {
-        return bucketIndex == 0 ? Duration.MIN_VALUE : specification.getDurationBuckets().get(bucketIndex - 1);
+        return bucketIndex == 0 ? Duration.MIN_VALUE : specification.getDurationUpperBounds().get(bucketIndex - 1);
     }
 
     private double getUpperBoundValueForBucket(int bucketIndex) {
-        return bucketIndex < specification.getValueBuckets().size() ? specification.getValueBuckets().get(bucketIndex) : Double.MAX_VALUE;
+        return bucketIndex < specification.getValueUpperBounds().size() ? specification.getValueUpperBounds().get(bucketIndex) : Double.MAX_VALUE;
     }
 
     private double getLowerBoundValueForBucket(int bucketIndex) {
-        return bucketIndex == 0 ? Double.MIN_VALUE : specification.getValueBuckets().get(bucketIndex - 1);
+        return bucketIndex == 0 ? Double.MIN_VALUE : specification.getValueUpperBounds().get(bucketIndex - 1);
     }
 
     private long getCounterValue(int index) {

--- a/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
@@ -79,7 +79,10 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
             return bucketCounters[index];
         }
 
-        List<Double> bucketsBounds = specification.getValueBuckets();
+        List<?> bucketsBounds =
+                this.type == Type.VALUE
+                        ? specification.getValueBuckets()
+                        : specification.getDurationBuckets();
 
         // To maintain lock granularity we synchronize only on a
         // particular bucket leveraging bucket's boundary as a sync target

--- a/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
@@ -23,8 +23,9 @@ package com.uber.m3.tally;
 import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -32,15 +33,14 @@ import java.util.Map;
  */
 class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
     private final Type type;
+
     private final ImmutableMap<String, String> tags;
-    private final Buckets specification;
+
+    private final ImmutableBuckets specification;
 
     // NOTE: Bucket counters are lazily initialized. Since ref updates are atomic in JMM,
     // no dedicated synchronization is used on the read path, only on the write path
     private final CounterImpl[] bucketCounters;
-
-    private final double[] lookupByValue;
-    private final Duration[] lookupByDuration;
 
     private final ScopeImpl scope;
 
@@ -60,25 +60,17 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
         // Each bucket value, serves as a boundary de-marking upper bound
         // for the bucket to the left, and lower bound for the bucket to the right
         this.bucketCounters = new CounterImpl[buckets.asValues().length + 1];
-
-        this.lookupByValue =
-                Arrays.stream(buckets.asValues())
-                    .mapToDouble(x -> x)
-                    .toArray();
-
-        this.lookupByDuration =
-                Arrays.copyOf(buckets.asDurations(), buckets.asDurations().length);
     }
 
     @Override
     public void recordValue(double value) {
-        int index = toBucketIndex(Arrays.binarySearch(lookupByValue, value));
+        int index = toBucketIndex(Collections.binarySearch(specification.getValueBuckets(), value));
         getOrCreateCounter(index).inc(1);
     }
 
     @Override
     public void recordDuration(Duration duration) {
-        int index = toBucketIndex(Arrays.binarySearch(lookupByDuration, duration));
+        int index = toBucketIndex(Collections.binarySearch(specification.getDurationBuckets(), duration));
         getOrCreateCounter(index).inc(1);
     }
 
@@ -87,9 +79,11 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
             return bucketCounters[index];
         }
 
+        List<Double> bucketsBounds = specification.getValueBuckets();
+
         // To maintain lock granularity we synchronize only on a
         // particular bucket leveraging bucket's boundary as a sync target
-        synchronized (lookupByDuration[Math.min(index, lookupByDuration.length - 1)]) {
+        synchronized (bucketsBounds.get(Math.min(index, bucketsBounds.size() - 1))) {
             // Check whether bucket has been already set,
             // while we were waiting for lock
             if (bucketCounters[index] != null) {
@@ -101,7 +95,7 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
         }
     }
 
-    private int toBucketIndex(int binarySearchResult) {
+    static int toBucketIndex(int binarySearchResult) {
         // Buckets are defined in the following way:
         //      - Each bucket is inclusive of its lower bound, and exclusive of the upper: [lower, upper)
         //      - All buckets are defined by upper bounds: [2, 4, 8, 16, 32, ...]: therefore i
@@ -133,19 +127,19 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
     }
 
     private Duration getUpperBoundDurationForBucket(int bucketIndex) {
-        return bucketIndex < lookupByDuration.length ? lookupByDuration[bucketIndex] : Duration.MAX_VALUE;
-    }
-
-    private double getUpperBoundValueForBucket(int bucketIndex) {
-        return bucketIndex < lookupByValue.length ? lookupByValue[bucketIndex] : Double.MAX_VALUE;
+        return bucketIndex < specification.getDurationBuckets().size() ? specification.getDurationBuckets().get(bucketIndex) : Duration.MAX_VALUE;
     }
 
     private Duration getLowerBoundDurationForBucket(int bucketIndex) {
-        return bucketIndex == 0 ? Duration.MIN_VALUE : lookupByDuration[bucketIndex - 1];
+        return bucketIndex == 0 ? Duration.MIN_VALUE : specification.getDurationBuckets().get(bucketIndex - 1);
+    }
+
+    private double getUpperBoundValueForBucket(int bucketIndex) {
+        return bucketIndex < specification.getValueBuckets().size() ? specification.getValueBuckets().get(bucketIndex) : Double.MAX_VALUE;
     }
 
     private double getLowerBoundValueForBucket(int bucketIndex) {
-        return bucketIndex == 0 ? Double.MIN_VALUE : lookupByValue[bucketIndex - 1];
+        return bucketIndex == 0 ? Double.MIN_VALUE : specification.getValueBuckets().get(bucketIndex - 1);
     }
 
     private long getCounterValue(int index) {
@@ -218,7 +212,7 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
                     reporter.reportHistogramValueSamples(
                         getQualifiedName(),
                         tags,
-                        specification,
+                        (Buckets) specification,
                         getLowerBoundValueForBucket(bucketIndex),
                         getUpperBoundValueForBucket(bucketIndex),
                         inc
@@ -228,7 +222,7 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
                     reporter.reportHistogramDurationSamples(
                         getQualifiedName(),
                         tags,
-                        specification,
+                        (Buckets) specification,
                         getLowerBoundDurationForBucket(bucketIndex),
                         getUpperBoundDurationForBucket(bucketIndex),
                         inc

--- a/core/src/main/java/com/uber/m3/tally/ImmutableBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/ImmutableBuckets.java
@@ -24,26 +24,64 @@ import com.uber.m3.util.Duration;
 
 import java.util.List;
 
+/**
+ * Abstracts buckets used in {@link Histogram} metrics,
+ *
+ * Buckets are defined by the list of upper-bounds in the following way:
+ *
+ *  <blockquote>
+ *  <pre>
+ *      double bounds[] = new double[] { 1, 2, 4, 8, 16 };
+ *
+ *      // For the given set of bounds:
+ *      //    first bucket      [-inf, 1)
+ *      //    second bucket     [1, 2)
+ *      //    ...
+ *      //    last bucket       [16, +inf)
+ *  <pre/>
+ *  </blockquote>
+ */
 public interface ImmutableBuckets {
 
+    /**
+     * Gets corresponding bucket lower bound
+     */
     double getValueLowerBoundFor(int bucketIndex);
+
+    /**
+     * Gets corresponding bucket upper bound
+     */
     double getValueUpperBoundFor(int bucketIndex);
 
+    /**
+     * Gets corresponding bucket lower bound
+     */
     Duration getDurationLowerBoundFor(int bucketIndex);
+
+    /**
+     * Gets corresponding bucket upper bound
+     */
     Duration getDurationUpperBoundFor(int bucketIndex);
 
+    /**
+     * Gets index of the corresponding bucket this value would fall under
+     */
     int getBucketIndexFor(double value);
+
+    /**
+     * Gets index of the corresponding bucket this value would fall under
+     */
     int getBucketIndexFor(Duration value);
 
     /**
-     * Returns these buckets as {@code double}s.
+     * Returns defined buckets' upper-bound values as {@link Double}s.
      * @return an immutable list of {@code double}s representing these buckets
      */
-    List<Double> getValueBuckets();
+    List<Double> getValueUpperBounds();
 
     /**
-     * Returns these buckets as {@link Duration}s.
+     * Returns defined buckets' upper-bound values as {@link Duration}s.
      * @return an immutable list of {@link Duration}s representing these buckets
      */
-    List<Duration> getDurationBuckets();
+    List<Duration> getDurationUpperBounds();
 }

--- a/core/src/main/java/com/uber/m3/tally/ImmutableBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/ImmutableBuckets.java
@@ -1,0 +1,30 @@
+package com.uber.m3.tally;
+
+import com.uber.m3.util.Duration;
+
+import java.util.List;
+
+public interface ImmutableBuckets {
+
+    double getValueLowerBoundFor(int bucketIndex);
+    double getValueUpperBoundFor(int bucketIndex);
+
+    Duration getDurationLowerBoundFor(int bucketIndex);
+    Duration getDurationUpperBoundFor(int bucketIndex);
+
+    int getBucketIndexFor(double value);
+    int getBucketIndexFor(Duration value);
+
+    /**
+     * Returns these buckets as {@code double}s.
+     * @return an immutable list of {@code double}s representing these buckets
+     */
+    List<Double> getValueBuckets();
+
+
+    /**
+     * Returns these buckets as {@link Duration}s.
+     * @return an immutable list of {@link Duration}s representing these buckets
+     */
+    List<Duration> getDurationBuckets();
+}

--- a/core/src/main/java/com/uber/m3/tally/ImmutableBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/ImmutableBuckets.java
@@ -38,7 +38,7 @@ import java.util.List;
  *      //    second bucket     [1, 2)
  *      //    ...
  *      //    last bucket       [16, +inf)
- *  <pre/>
+ *  </pre>
  *  </blockquote>
  */
 public interface ImmutableBuckets {

--- a/core/src/main/java/com/uber/m3/tally/ImmutableBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/ImmutableBuckets.java
@@ -1,3 +1,23 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package com.uber.m3.tally;
 
 import com.uber.m3.util.Duration;
@@ -20,7 +40,6 @@ public interface ImmutableBuckets {
      * @return an immutable list of {@code double}s representing these buckets
      */
     List<Double> getValueBuckets();
-
 
     /**
      * Returns these buckets as {@link Duration}s.

--- a/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
@@ -25,6 +25,7 @@ import com.uber.m3.util.ImmutableMap;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -89,7 +90,14 @@ class ScopeImpl implements Scope {
     public Histogram histogram(String name, Buckets buckets) {
         return histograms.computeIfAbsent(name, ignored ->
                 // NOTE: This will called at most once
-                new HistogramImpl(this, fullyQualifiedName(name), tags, buckets));
+                new HistogramImpl(
+                        this,
+                        fullyQualifiedName(name),
+                        tags,
+                        Optional.ofNullable(buckets)
+                                .orElse(defaultBuckets)
+                )
+        );
     }
 
     @Override

--- a/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
@@ -49,7 +49,7 @@ public class ValueBuckets extends AbstractBuckets<Double> {
     }
 
     @Override
-    public List<Double> getValueBuckets() {
+    public List<Double> getValueUpperBounds() {
         return Collections.unmodifiableList(buckets);
     }
 
@@ -69,7 +69,7 @@ public class ValueBuckets extends AbstractBuckets<Double> {
     }
 
     @Override
-    public List<Duration> getDurationBuckets() {
+    public List<Duration> getDurationUpperBounds() {
         throw new UnsupportedOperationException("not supported");
     }
 

--- a/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
@@ -67,7 +67,6 @@ public class ValueBuckets extends AbstractBuckets<Double> {
         throw new UnsupportedOperationException("not supported");
     }
 
-
     @Override
     public int getBucketIndexFor(Duration value) {
         throw new UnsupportedOperationException("not supported");

--- a/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
@@ -22,6 +22,9 @@ package com.uber.m3.tally;
 
 import com.uber.m3.util.Duration;
 
+import java.util.Collections;
+import java.util.List;
+
 /**
  * {@link Buckets} implementation backed by {@code Double} values.
  */
@@ -35,10 +38,59 @@ public class ValueBuckets extends AbstractBuckets<Double> {
     }
 
     @Override
+    public double getValueLowerBoundFor(int bucketIndex) {
+        return bucketIndex == 0 ? Double.MIN_VALUE : buckets.get(bucketIndex - 1);
+    }
+
+    @Override
+    public double getValueUpperBoundFor(int bucketIndex) {
+        return bucketIndex < buckets.size() ? buckets.get(bucketIndex) : Double.MAX_VALUE;
+    }
+
+    @Override
+    public int getBucketIndexFor(double value) {
+        return HistogramImpl.toBucketIndex(Collections.binarySearch(buckets, value));
+    }
+
+    @Override
+    public List<Double> getValueBuckets() {
+        return Collections.unmodifiableList(buckets);
+    }
+
+    @Override
+    public Duration getDurationLowerBoundFor(int bucketIndex) {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    @Override
+    public Duration getDurationUpperBoundFor(int bucketIndex) {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+
+    @Override
+    public int getBucketIndexFor(Duration value) {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    @Override
+    public List<Duration> getDurationBuckets() {
+        throw new UnsupportedOperationException("not supported");
+    }
+
+    /**
+     * @deprecated DO NOT USE
+     */
+    @Deprecated
+    @Override
     public Double[] asValues() {
         return buckets.toArray(new Double[buckets.size()]);
     }
 
+    /**
+     * @deprecated DO NOT USE
+     */
+    @Deprecated
     @Override
     public Duration[] asDurations() {
         Duration[] durations = new Duration[buckets.size()];

--- a/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
@@ -33,10 +33,6 @@ public class ValueBuckets extends AbstractBuckets<Double> {
         super(values);
     }
 
-    public ValueBuckets() {
-        super();
-    }
-
     @Override
     public double getValueLowerBoundFor(int bucketIndex) {
         return bucketIndex == 0 ? Double.MIN_VALUE : buckets.get(bucketIndex - 1);

--- a/core/src/main/java/com/uber/m3/util/ImmutableList.java
+++ b/core/src/main/java/com/uber/m3/util/ImmutableList.java
@@ -169,4 +169,9 @@ public class ImmutableList<E> implements List<E> {
     public int hashCode() {
         return collection.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return collection.toString();
+    }
 }

--- a/core/src/test/java/com/uber/m3/tally/DurationBucketsTest.java
+++ b/core/src/test/java/com/uber/m3/tally/DurationBucketsTest.java
@@ -20,21 +20,17 @@
 
 package com.uber.m3.tally;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
-
+import com.uber.m3.util.Duration;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
-import com.uber.m3.util.Duration;
+import java.util.Iterator;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class DurationBucketsTest {
     @Test
@@ -49,80 +45,6 @@ public class DurationBucketsTest {
                 assertEquals(Duration.ofMillis(100 + 10 * i), iter.next());
             }
         }
-
-        buckets.add(Duration.ofMillis(160));
-        assertEquals(Duration.ofMillis(160), buckets.get(6));
-
-        buckets.set(6, Duration.ofMillis(170));
-        assertEquals(Duration.ofMillis(170), buckets.get(6));
-
-        buckets.add(6, Duration.ofMillis(160));
-        assertEquals(Duration.ofMillis(160), buckets.get(6));
-
-        ArrayList<Duration> additionalDurations = new ArrayList<>();
-        additionalDurations.add(Duration.ofMillis(200));
-        additionalDurations.add(Duration.ofMillis(210));
-        buckets.addAll(additionalDurations);
-
-        additionalDurations = new ArrayList<>();
-        additionalDurations.add(Duration.ofMillis(180));
-        additionalDurations.add(Duration.ofMillis(190));
-        buckets.addAll(8, additionalDurations);
-
-        buckets.add(Duration.ofMillis(220));
-        buckets.add(Duration.ofMillis(220));
-
-        assertEquals(12, buckets.indexOf(Duration.ofMillis(220)));
-        assertEquals(13, buckets.lastIndexOf(Duration.ofMillis(220)));
-
-        buckets.remove(12);
-        assertEquals(13, buckets.size());
-        assertEquals(Duration.ofMillis(220), buckets.get(12));
-        buckets.remove(12);
-        assertEquals(12, buckets.size());
-
-        ListIterator<Duration> iter = buckets.listIterator(11);
-        assertTrue(iter.hasNext());
-        assertTrue(iter.hasPrevious());
-        assertEquals(Duration.ofMillis(210), iter.next());
-        assertFalse(iter.hasNext());
-
-        assertTrue(buckets.containsAll(additionalDurations));
-
-        List<Duration> durationList = buckets.subList(0, 2);
-        assertEquals(2, durationList.size());
-        assertEquals(Duration.ofMillis(100), buckets.get(0));
-        assertEquals(Duration.ofMillis(110), buckets.get(1));
-
-        assertTrue(buckets.retainAll(durationList));
-        assertEquals(2, buckets.size());
-
-        assertArrayEquals(new Duration[]{Duration.ofMillis(100), Duration.ofMillis(110)}, buckets.toArray());
-
-        durationList = new ArrayList<>();
-        durationList.add(Duration.ofMillis(100));
-        assertTrue(buckets.removeAll(durationList));
-        assertEquals(1, buckets.size());
-        assertEquals(Duration.ofMillis(110), buckets.get(0));
-
-        Duration[] durationArr = new Duration[1];
-        assertArrayEquals(durationArr, buckets.toArray(durationArr));
-
-        assertFalse(buckets.remove(Duration.ofMillis(999)));
-        assertTrue(buckets.remove(Duration.ofMillis(110)));
-
-        assertEquals(0, buckets.size());
-
-        durationList.add(Duration.ofMillis(110));
-        durationList.add(Duration.ofMillis(120));
-        durationList.add(Duration.ofMillis(130));
-        durationList.add(Duration.ofMillis(140));
-        buckets.addAll(durationList);
-
-        assertEquals(5, buckets.size());
-
-        buckets.clear();
-        assertEquals(0, buckets.size());
     }
 
     @Test
@@ -249,9 +171,6 @@ public class DurationBucketsTest {
     public void testToString() {
         DurationBuckets buckets = DurationBuckets.linear(Duration.ZERO, Duration.ofMillis(10), 6);
         assertEquals("[0s, 10ms, 20ms, 30ms, 40ms, 50ms]", buckets.toString());
-
-        buckets = new DurationBuckets();
-        assertEquals("[]", buckets.toString());
 
         buckets = new DurationBuckets(new Duration[]{Duration.ofHours(1)});
         assertEquals("[1h]", buckets.toString());

--- a/core/src/test/java/com/uber/m3/tally/HistogramImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/HistogramImplTest.java
@@ -37,6 +37,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class HistogramImplTest {
+
+    private static final double[] BUCKETS = new double[] {
+        1.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 125.0, 150.0, 175.0, 200.0,
+        225.0, 250.0, 300.0, 350.0, 400.0, 450.0, 500.0, 550.0, 600.0, 650.0, 700.0, 750.0, 800.0, 850.0, 900.0, 950.0, 1000.0
+    };
+
     private TestStatsReporter reporter;
     private ScopeImpl scope;
 
@@ -50,11 +56,6 @@ public class HistogramImplTest {
                 .reporter(reporter)
                 .build();
     }
-
-    private static final double BUCKETS[] = new double[]{
-            1.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 125.0, 150.0, 175.0, 200.0,
-            225.0, 250.0, 300.0, 350.0, 400.0, 450.0, 500.0, 550.0, 600.0, 650.0, 700.0, 750.0, 800.0, 850.0, 900.0, 950.0, 1000.0
-    };
 
     @Test
     public void test() {

--- a/core/src/test/java/com/uber/m3/tally/HistogramImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/HistogramImplTest.java
@@ -21,12 +21,17 @@
 package com.uber.m3.tally;
 
 import com.uber.m3.util.Duration;
+import com.uber.m3.util.ImmutableMap;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -44,6 +49,51 @@ public class HistogramImplTest {
             new ScopeBuilder(null, new ScopeImpl.Registry())
                 .reporter(reporter)
                 .build();
+    }
+
+    private static final double BUCKETS[] = new double[]{
+            1.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 125.0, 150.0, 175.0, 200.0,
+            225.0, 250.0, 300.0, 350.0, 400.0, 450.0, 500.0, 550.0, 600.0, 650.0, 700.0, 750.0, 800.0, 850.0, 900.0, 950.0, 1000.0
+    };
+
+    @Test
+    public void test() {
+        histogram = new HistogramImpl(scope, "histogram", ImmutableMap.EMPTY, ValueBuckets.custom(BUCKETS));
+
+        double maxUpperBound = BUCKETS[BUCKETS.length - 1];
+
+        List<Double> values =
+                IntStream.range(0, 10000)
+                    .mapToDouble(ignored -> Math.random() * (maxUpperBound + 1))
+                    .mapToObj(a -> a)
+                    .collect(Collectors.toList());
+
+        Map<Double, Long> expected = new HashMap<>();
+
+        for (int i = 0; i < values.size(); ++i) {
+            int index = Arrays.binarySearch(BUCKETS, values.get(i));
+            double upper;
+            if (index >= 0) {
+                upper = index + 1 < BUCKETS.length ? BUCKETS[index + 1] : Double.MAX_VALUE;
+            } else {
+                upper = ~index < BUCKETS.length ? BUCKETS[~index] : Double.MAX_VALUE;
+            }
+
+            expected.put(upper, expected.getOrDefault(upper, 0L) + 1);
+
+            ////////////////////////////////////////////////////
+
+            histogram.recordValue(values.get(i));
+
+            if (i % 13 == 0) {
+                scope.report(reporter);
+            }
+
+        }
+
+        scope.report(reporter);
+
+        assertEquals(reporter.getCumulativeValueSamples(), expected);
     }
 
     @Test

--- a/core/src/test/java/com/uber/m3/tally/ScopeImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/ScopeImplTest.java
@@ -76,7 +76,14 @@ public class ScopeImplTest {
         );
         assertNotNull(histogram);
 
+        Histogram histogramDefaultBuckets = scope.histogram(
+                "new-histogram-default-buckets",
+                null
+        );
+        assertNotNull(histogramDefaultBuckets);
+
         Histogram sameHistogram = scope.histogram("new-histogram", null);
+
         // Should be the same Histogram object and not a new instance
         assertTrue(histogram == sameHistogram);
     }

--- a/core/src/test/java/com/uber/m3/tally/TestStatsReporter.java
+++ b/core/src/test/java/com/uber/m3/tally/TestStatsReporter.java
@@ -35,6 +35,8 @@ public class TestStatsReporter implements StatsReporter {
     private Map<Double, Long> valueSamples = new HashMap<>();
     private Map<Duration, Long> durationSamples = new HashMap<>();
 
+    private Map<Double, Long> cumulativeValueSamples = new HashMap<>();
+
     @Override
     public void reportCounter(String name, Map<String, String> tags, long value) {
         counters.add(new MetricStruct<>(name, tags, value));
@@ -83,6 +85,10 @@ public class TestStatsReporter implements StatsReporter {
         long samples
     ) {
         valueSamples.put(bucketUpperBound, samples);
+        cumulativeValueSamples.put(
+                bucketUpperBound,
+                cumulativeValueSamples.getOrDefault(bucketUpperBound, 0L) + samples
+        );
         this.buckets = buckets;
     }
 
@@ -120,6 +126,10 @@ public class TestStatsReporter implements StatsReporter {
 
     public Map<Double, Long> getValueSamples() {
         return valueSamples;
+    }
+
+    public Map<Double, Long> getCumulativeValueSamples() {
+        return cumulativeValueSamples;
     }
 
     public Buckets getBuckets() {

--- a/core/src/test/java/com/uber/m3/tally/ValueBucketsTest.java
+++ b/core/src/test/java/com/uber/m3/tally/ValueBucketsTest.java
@@ -142,9 +142,6 @@ public class ValueBucketsTest {
         ValueBuckets buckets = ValueBuckets.linear(0, 10, 6);
         assertEquals("[0.0, 10.0, 20.0, 30.0, 40.0, 50.0]", buckets.toString());
 
-        buckets = new ValueBuckets();
-        assertEquals("[]", buckets.toString());
-
         buckets = new ValueBuckets(new Double[]{99.99});
         assertEquals("[99.99]", buckets.toString());
     }

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -43,6 +43,7 @@ import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -383,9 +384,13 @@ public class M3ReporterTest {
         expectedTags.put("foo", "bar");
         expectedTags.put("bucketid", "0001");
         expectedTags.put("bucket", "0.000000-25000000.000000");
-        for (MetricTag tag : metric.getTags()) {
-            assertEquals(expectedTags.get(tag.getTagName()), tag.getTagValue());
-        }
+
+        Map<String, String> receivedTags =
+                metric.getTags()
+                        .stream()
+                        .collect(Collectors.toMap(MetricTag::getTagName, MetricTag::getTagValue));
+
+        assertEquals(expectedTags, receivedTags);
 
         assertTrue(metric.isSetMetricValue());
 


### PR DESCRIPTION
Subject;

NOTE: There's a breaking change: `DurationBuckets` and `LatencyBuckets` will no longer be modifiable.

Introduced `ImmutableBuckets` interface to eventually replaced `Buckets`;
Rebased `HistogramImpl`, `M3Reporter` onto `ImmutableBuckets`