### PR TITLE
Fixing M3Reporter to reboot Processors upon failure

### DIFF
--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -259,6 +259,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
 
         // Important to use `shutdownNow` instead of `shutdown` to interrupt processor
         // thread(s) or else they will block forever
+        scheduledExecutorService.shutdownNow();
         executorService.shutdownNow();
 
         try {

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -87,6 +87,13 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
     public static final String DEFAULT_HISTOGRAM_BUCKET_NAME = "bucket";
     public static final int DEFAULT_HISTOGRAM_BUCKET_TAG_PRECISION = 6;
 
+    /**
+     * NOTE: DO NOT CHANGE THIS NUMBER!
+     *       Reporter architecture is not suited for multi-processor setup and might cause some disruption
+     *       to how metrics are processed and eventually submitted to M3 collectors;
+     */
+    static final int NUM_PROCESSORS = 1;
+
     private static final Logger LOG = LoggerFactory.getLogger(M3Reporter.class);
 
     private static final int MAX_DELAY_BEFORE_FLUSHING_MILLIS = 1_000;
@@ -101,13 +108,6 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
     private static final int THRIFT_METADATA_PADDING = 256;
 
     private static final int MIN_METRIC_BUCKET_ID_TAG_LENGTH = 4;
-
-    /**
-     * NOTE: DO NOT CHANGE THIS NUMBER!
-     *       Reporter architecture is not suited for multi-processor setup and might cause some disruption
-     *       to how metrics are processed and eventually submitted to M3 collectors;
-     */
-    static final int NUM_PROCESSORS = 1;
 
     private static final ThreadLocal<SerializedPayloadSizeEstimator> PAYLOAD_SIZE_ESTIMATOR =
             ThreadLocal.withInitial(SerializedPayloadSizeEstimator::new);

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -243,13 +243,6 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
         }
     }
 
-    // NOTE: This should only be used in tests
-    void flushNow() throws TException {
-        for (Processor processor : processors) {
-            processor.flushBuffered();
-        }
-    }
-
     @Override
     public void close() {
         if (!isShutdown.compareAndSet(false, true)) {

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -94,6 +94,8 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
      */
     static final int NUM_PROCESSORS = 1;
 
+    static final Duration HEARTBEAT_PERIOD = Duration.ofSeconds(10);
+
     private static final Logger LOG = LoggerFactory.getLogger(M3Reporter.class);
 
     private static final int MAX_DELAY_BEFORE_FLUSHING_MILLIS = 1_000;
@@ -178,7 +180,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
         }
 
         // Schedule regular heartbeat up-keeping processors up and running
-        scheduledExecutorService.scheduleAtFixedRate(this::heartbeat, 1, 1, TimeUnit.SECONDS);
+        scheduledExecutorService.scheduleAtFixedRate(this::heartbeat, 0, HEARTBEAT_PERIOD.toMillis(), TimeUnit.MILLISECONDS);
     }
 
     // NOTE: This method is not concurrent

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -133,7 +133,7 @@ public class M3ReporterTest {
 
             // We simply block here awaiting for reporter to re-create processors, subsequently
             // invoking Thrift factory again
-            boolean countdown = latch.await(5, TimeUnit.SECONDS);
+            boolean countdown = latch.await((long) (M3Reporter.HEARTBEAT_PERIOD.getSeconds() + 1), TimeUnit.SECONDS);
 
             assertTrue(countdown);
         }


### PR DESCRIPTION
Currently crashed `Processor` would eventually lead to the `M3Reporter` queue to overflow and block on attempts to add metrics to it stalling the calling application.

This change makes `M3Reporter` more resilient by adding heartbeat sequence checking the state of the processors and rebooting the failings ones. 

It also makes sure that addition to the queue never jams the application itself.

More details could be found in T6503863.