### PR TITLE
Add an `open` flag to `TUdpTransport`

### DIFF
--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
@@ -50,6 +50,7 @@ public class TUdpClient extends TUdpTransport implements AutoCloseable {
     public void open() throws TTransportException {
         try {
             socket.connect(socketAddress);
+            open = true;
 
             logger.info("UDP socket has been opened");
         } catch (SocketException e) {

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpServer.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpServer.java
@@ -57,6 +57,7 @@ public class TUdpServer extends TUdpTransport implements AutoCloseable {
         try {
             socket.bind(socketAddress);
             socket.setSoTimeout(timeoutMillis);
+            open = true;
 
             logger.info("UDP socket has been bound to");
         } catch (SocketException e) {

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -50,6 +50,8 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
     protected final SocketAddress socketAddress;
     protected final DatagramSocket socket;
 
+    // NOTE: We're using dedicated boolean flag to avoid invoking {@link DatagramSocket#isOpen} directly
+    //       on the hot-path which is checking the state of the socket under lock.
     protected volatile boolean open;
 
     @GuardedBy("sendLock")

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpTransport.java
@@ -50,6 +50,8 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
     protected final SocketAddress socketAddress;
     protected final DatagramSocket socket;
 
+    protected volatile boolean open;
+
     @GuardedBy("sendLock")
     protected ByteBuffer writeBuffer;
 
@@ -69,6 +71,7 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
         // Resets receiving buffer to 0, to make sure it isn't readable
         // until it would be first written
         this.receiveBuffer.limit(0);
+        this.open = false;
     }
 
     protected TUdpTransport(SocketAddress socketAddress) throws SocketException {
@@ -77,7 +80,7 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
 
     @Override
     public boolean isOpen() {
-        return !socket.isClosed();
+        return open;
     }
 
     @Override
@@ -86,6 +89,7 @@ public abstract class TUdpTransport extends TTransport implements AutoCloseable 
     @Override
     public void close() {
         socket.close();
+        open = false;
 
         logger.info("UDP socket has been closed");
     }

--- a/m3/src/test/java/com/uber/m3/tally/m3/thrift/TUdpClientTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/thrift/TUdpClientTest.java
@@ -80,8 +80,10 @@ public class TUdpClientTest {
         );
     }
 
-    private static TUdpClient createUdpClient(DatagramSocket mockedSocket) {
-        return new TUdpClient(InetSocketAddress.createUnresolved("0.0.0.0", 0), mockedSocket);
+    private static TUdpClient createUdpClient(DatagramSocket mockedSocket) throws TTransportException {
+        TUdpClient client = new TUdpClient(InetSocketAddress.createUnresolved("0.0.0.0", 0), mockedSocket);
+        client.open();
+        return client;
     }
 
 }


### PR DESCRIPTION
Add an `open` flag to `TUdpTransport` to avoid querying `DatagramSocket::isOpen` on the hot-path (incurs lock acquiring)