### PR TITLE
Add WIP warnings around prom reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ All artifacts are published under the group `com.uber.m3`.
 1. `tally-statsd`: The tally StatsD reporter
 1. `tally-core`: tally core functionality that includes interfaces and utilities to report metrics to M3
 1. `tally-example`: Example usages with different reporters
-1. `tally-prometheus`: The tally Prometheus reporter
+1. `tally-prometheus`: The tally Prometheus reporter (experimental; see prometheus/README.md)
 
 ## Versioning
 We follow semantic versioning outlined [here](http://semver.org/spec/v2.0.0.html). In summary,

--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -1,0 +1,9 @@
+# tally-prometheus
+
+A tally reporter which exposes metrics to be scraped by Prometheus.
+
+## WIP
+
+Still experimental; see https://github.com/uber-java/tally/issues/93.
+
+The tally prometheus packages will be moved from com.uber.m3.tally.experimental.prometheus once the package is GA.

--- a/prometheus/src/main/java/com/uber/m3/tally/experimental/prometheus/PrometheusReporter.java
+++ b/prometheus/src/main/java/com/uber/m3/tally/experimental/prometheus/PrometheusReporter.java
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package com.uber.m3.tally.prometheus;
+package com.uber.m3.tally.experimental.prometheus;
 
 import com.uber.m3.tally.Buckets;
 import com.uber.m3.tally.Capabilities;

--- a/prometheus/src/main/java/com/uber/m3/tally/experimental/prometheus/TimerType.java
+++ b/prometheus/src/main/java/com/uber/m3/tally/experimental/prometheus/TimerType.java
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package com.uber.m3.tally.prometheus;
+package com.uber.m3.tally.experimental.prometheus;
 
 /**
  * {@link com.uber.m3.tally.Timer} metric can be represented as {@link io.prometheus.client.Summary} or

--- a/prometheus/src/test/java/com/uber/m3/tally/experimental/prometheus/PrometheusReporterTest.java
+++ b/prometheus/src/test/java/com/uber/m3/tally/experimental/prometheus/PrometheusReporterTest.java
@@ -17,7 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-package com.uber.m3.tally.prometheus;
+package com.uber.m3.tally.experimental.prometheus;
 
 import com.uber.m3.tally.Buckets;
 import com.uber.m3.tally.DurationBuckets;
@@ -46,8 +46,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
-import static com.uber.m3.tally.prometheus.PrometheusReporter.METRIC_ID_KEY_VALUE;
-import static com.uber.m3.tally.prometheus.PrometheusReporter.collectionToStringArray;
+import static com.uber.m3.tally.experimental.prometheus.PrometheusReporter.METRIC_ID_KEY_VALUE;
+import static com.uber.m3.tally.experimental.prometheus.PrometheusReporter.collectionToStringArray;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;


### PR DESCRIPTION
As discussed with @alexeykudinkin and @SokolAndrey, we're not quite ready to have the prom reporter actively used by folks. It's already released (hard to undo), but we can at least give users a heads up for the time being. I figure we can probably remove these once we've addressed perf concerns and maybe done some baking of the lib within Uber.