### PR TITLE
Add @Nullable annotation to histogram to make it work with the NullAway linter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,8 @@ allprojects {
     }
 
     dependencies {
+        compile 'com.google.code.findbugs:jsr305:3.0.2'
+
         testCompile 'junit:junit:4.12'
         testCompile 'org.mockito:mockito-core:[1.0, 2.0)'
         testCompile 'ch.qos.logback:logback-classic:1.2.3'

--- a/core/src/main/java/com/uber/m3/tally/NoopScope.java
+++ b/core/src/main/java/com/uber/m3/tally/NoopScope.java
@@ -24,6 +24,8 @@ import java.util.Map;
 
 import com.uber.m3.util.Duration;
 
+import javax.annotation.Nullable;
+
 /**
  * Noop implementation of Scope.
  */
@@ -94,7 +96,7 @@ public class NoopScope implements Scope {
 
     @Override
     @SuppressWarnings("rawtypes")
-    public Histogram histogram(String name, Buckets buckets) {
+    public Histogram histogram(String name, @Nullable Buckets buckets) {
         return NOOP_HISTOGRAM;
     }
 

--- a/core/src/main/java/com/uber/m3/tally/Scope.java
+++ b/core/src/main/java/com/uber/m3/tally/Scope.java
@@ -20,6 +20,7 @@
 
 package com.uber.m3.tally;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
@@ -51,10 +52,10 @@ public interface Scope extends AutoCloseable {
     /**
      * Creates and returns a {@link Histogram} with specified name and buckets.
      * @param name the name of this {@link Histogram}
-     * @param buckets the buckets of this {@link Histogram}
+     * @param buckets the buckets of this {@link Histogram}. If null, default buckets will be used.
      * @return a {@link Histogram} with the specified name and buckets
      */
-    Histogram histogram(String name, Buckets buckets);
+    Histogram histogram(String name, @Nullable Buckets buckets);
 
     /**
      * Returns a child scope with the given and current tags.

--- a/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
@@ -22,6 +22,7 @@ package com.uber.m3.tally;
 
 import com.uber.m3.util.ImmutableMap;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -87,7 +88,7 @@ class ScopeImpl implements Scope {
     }
 
     @Override
-    public Histogram histogram(String name, Buckets buckets) {
+    public Histogram histogram(String name, @Nullable Buckets buckets) {
         return histograms.computeIfAbsent(name, ignored ->
                 // NOTE: This will called at most once
                 new HistogramImpl(


### PR DESCRIPTION
A user pointed out that there's no way currently to use the default buckets (specified via `null`) in a project that
uses https://github.com/uber/NullAway. That library assumes that anything unannotated is @NotNull, which is aggressive but probably the right move. To remedy this, I've just gone and explicitly marked `histogram` as nullable.

We can annotate further as we get time/touch the code naturally.

A note r.e. the findbugs dependency--this seems like a fairly standard source for the annotation, but if there's a better one let me know.