### PR TITLE
Optimizing M3 Reporter

### DIFF
--- a/core/benchmark-tests.txt
+++ b/core/benchmark-tests.txt
@@ -1,0 +1,9 @@
+Benchmark                                                        Mode  Cnt     Score    Error    Units
+ScopeImplBenchmark.scopeReportingBenchmark                      thrpt   10  1385.711 ± 55.291   ops/ms
+ScopeImplBenchmark.scopeReportingBenchmark:·async               thrpt            NaN               ---
+ScopeImplBenchmark.scopeReportingBenchmark:·gc.alloc.rate       thrpt   10    ≈ 10⁻⁴            MB/sec
+ScopeImplBenchmark.scopeReportingBenchmark:·gc.alloc.rate.norm  thrpt   10    ≈ 10⁻⁴              B/op
+ScopeImplBenchmark.scopeReportingBenchmark:·gc.count            thrpt   10       ≈ 0            counts
+ScopeImplBenchmark.scopeReportingBenchmark:·threads.alive       thrpt   10     5.800 ±  0.637  threads
+ScopeImplBenchmark.scopeReportingBenchmark:·threads.daemon      thrpt   10     4.000 ±  0.001  threads
+ScopeImplBenchmark.scopeReportingBenchmark:·threads.started     thrpt   10    26.000           threads

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -25,6 +25,7 @@ sourceSets {
     jmh {
         java.srcDirs = ['src/jmh/java']
         resources.srcDirs = ['src/jmh/resources']
+
         compileClasspath += sourceSets.main.runtimeClasspath
         compileClasspath += sourceSets.test.runtimeClasspath
     }
@@ -39,6 +40,22 @@ task runJmhTests(type: JavaExec, dependsOn: jmhClasses) {
 
     args '-rf', 'text'
     args '-rff', resultFile
+
+    // Profile using GC, Threading profilers
+    args '-prof', 'gc'
+    args '-prof', 'hs_thr'
+
+    // Profile using async-profiling
+    //
+    // NOTE: For this to work you need to make sure that async-profiler's library is either
+    //          - Available in LD_LIBRARY_PATH (Linux), DYLD_LIBRARY_PATH (Mac)
+    //          - Available in '-Djava.library.path'
+    //          - Explicitly specified with 'async:libPath=</path/libasyncProfiler.so>'
+    args '-prof', 'async:event=cpu;direction=forward;output=flamegraph'
+
+    // Force GC after every iterations, to make sure that one iteration
+    // doesn't affect the other one
+    args '-gc', 'true'
 }
 
 classes.finalizedBy(jmhClasses)

--- a/core/src/jmh/java/com/uber/m3/tally/AbstractReporterBenchmark.java
+++ b/core/src/jmh/java/com/uber/m3/tally/AbstractReporterBenchmark.java
@@ -151,7 +151,10 @@ public abstract class AbstractReporterBenchmark<Reporter extends StatsReporter> 
     }
 
     public abstract Reporter bootReporter();
-    public abstract void shutdownReporter(Reporter reporter);
+
+    public void shutdownReporter(Reporter reporter) {
+        reporter.close();
+    }
 
     @State(Scope.Thread)
     public static class Counter {

--- a/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledExecutorService;
 
 /**
@@ -49,7 +49,7 @@ class ScopeImpl implements Scope {
     private final ConcurrentHashMap<String, GaugeImpl> gauges = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, HistogramImpl> histograms = new ConcurrentHashMap<>();
 
-    private final ConcurrentLinkedQueue<Reportable> reportingQueue = new ConcurrentLinkedQueue<>();
+    private final CopyOnWriteArrayList<Reportable> reportingList = new CopyOnWriteArrayList<>();
 
     private final ConcurrentHashMap<String, TimerImpl> timers = new ConcurrentHashMap<>();
 
@@ -137,7 +137,7 @@ class ScopeImpl implements Scope {
     }
 
     <T extends Reportable> void addToReportingQueue(T metric) {
-        reportingQueue.add(metric);
+        reportingList.add(metric);
     }
 
     /**
@@ -145,7 +145,7 @@ class ScopeImpl implements Scope {
      * @param reporter the reporter to report
      */
     void report(StatsReporter reporter) {
-        for (Reportable metric : reportingQueue) {
+        for (Reportable metric : reportingList) {
             metric.report(tags, reporter);
         }
     }

--- a/core/src/main/java/com/uber/m3/util/ListSet.java
+++ b/core/src/main/java/com/uber/m3/util/ListSet.java
@@ -1,0 +1,95 @@
+package com.uber.m3.util;
+
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+
+
+/**
+ * We're creating this surrogate structure to avoid incurring penalties
+ * associated w/ {@code HashSet}s (like computing hash-codes for every inserted element),
+ * since we aren't leveraging {@code HashSet}'s primary advantage (fast lookups)
+ *
+ * NOTE: This structure does NOT validate whether element is already present in the
+ *       set, therefore relying on the caller do the validation prior to insertion to
+ *       maintain {@link Set} invariant that there are no duplicates present
+ *
+ * @param <E> type of the element stored
+ */
+public class ListSet<E> extends ArrayList<E> implements Set<E> {
+
+    public ListSet() {}
+
+    public ListSet(int initialCapacity) {
+        super(initialCapacity);
+    }
+
+    @Override
+    public int size() {
+        return super.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return super.contains(o);
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return super.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return super.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return super.toArray(a);
+    }
+
+    @Override
+    public boolean add(E e) {
+        return super.add(e);
+    }
+
+
+    @Override
+    public boolean remove(Object o) {
+        return super.remove(o);
+    }
+
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return super.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        return super.addAll(c);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return super.retainAll(c);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return super.removeAll(c);
+    }
+
+    @Override
+    public void clear() {
+        super.clear();
+    }
+}

--- a/m3/benchmark-tests.txt
+++ b/m3/benchmark-tests.txt
@@ -1,52 +1,89 @@
-Benchmark                                                                                  Mode  Cnt      Score     Error   Units
-M3ReporterBenchmark.reportCounterBenchmark                                                thrpt   10    392.408 ± 172.561  ops/ms
-M3ReporterBenchmark.reportCounterBenchmark:·gc.alloc.rate                                 thrpt   10    862.566 ± 422.341  MB/sec
-M3ReporterBenchmark.reportCounterBenchmark:·gc.alloc.rate.norm                            thrpt   10   2420.767 ± 497.925    B/op
-M3ReporterBenchmark.reportCounterBenchmark:·gc.churn.G1_Eden_Space                        thrpt   10    920.157 ± 410.566  MB/sec
-M3ReporterBenchmark.reportCounterBenchmark:·gc.churn.G1_Eden_Space.norm                   thrpt   10   2580.137 ±  48.527    B/op
-M3ReporterBenchmark.reportCounterBenchmark:·gc.churn.G1_Old_Gen                           thrpt   10      0.981 ±   0.668  MB/sec
-M3ReporterBenchmark.reportCounterBenchmark:·gc.churn.G1_Old_Gen.norm                      thrpt   10      2.648 ±   0.815    B/op
-M3ReporterBenchmark.reportCounterBenchmark:·gc.churn.G1_Survivor_Space                    thrpt   10      1.675 ±   0.539  MB/sec
-M3ReporterBenchmark.reportCounterBenchmark:·gc.churn.G1_Survivor_Space.norm               thrpt   10      4.823 ±   0.988    B/op
-M3ReporterBenchmark.reportCounterBenchmark:·gc.count                                      thrpt   10    321.000            counts
-M3ReporterBenchmark.reportCounterBenchmark:·gc.time                                       thrpt   10   1332.000                ms
-M3ReporterBenchmark.reportGaugeBenchmark                                                  thrpt   10    506.871 ±  53.089  ops/ms
-M3ReporterBenchmark.reportGaugeBenchmark:·gc.alloc.rate                                   thrpt   10   1102.440 ± 243.462  MB/sec
-M3ReporterBenchmark.reportGaugeBenchmark:·gc.alloc.rate.norm                              thrpt   10   2397.555 ± 495.228    B/op
-M3ReporterBenchmark.reportGaugeBenchmark:·gc.churn.G1_Eden_Space                          thrpt   10   1177.270 ± 126.442  MB/sec
-M3ReporterBenchmark.reportGaugeBenchmark:·gc.churn.G1_Eden_Space.norm                     thrpt   10   2558.068 ±  24.291    B/op
-M3ReporterBenchmark.reportGaugeBenchmark:·gc.churn.G1_Old_Gen                             thrpt   10      0.994 ±   0.234  MB/sec
-M3ReporterBenchmark.reportGaugeBenchmark:·gc.churn.G1_Old_Gen.norm                        thrpt   10      2.151 ±   0.345    B/op
-M3ReporterBenchmark.reportGaugeBenchmark:·gc.churn.G1_Survivor_Space                      thrpt   10      2.779 ±   0.911  MB/sec
-M3ReporterBenchmark.reportGaugeBenchmark:·gc.churn.G1_Survivor_Space.norm                 thrpt   10      6.003 ±   1.452    B/op
-M3ReporterBenchmark.reportGaugeBenchmark:·gc.count                                        thrpt   10    411.000            counts
-M3ReporterBenchmark.reportGaugeBenchmark:·gc.time                                         thrpt   10   1279.000                ms
-M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark                               thrpt   10    188.096 ±   7.091  ops/ms
-M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.alloc.rate                thrpt   10   1367.823 ± 127.617  MB/sec
-M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.alloc.rate.norm           thrpt   10   8010.377 ± 722.215    B/op
-M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.churn.G1_Eden_Space       thrpt   10   1409.238 ±  58.465  MB/sec
-M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.churn.G1_Eden_Space.norm  thrpt   10   8251.019 ±  77.856    B/op
-M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.churn.G1_Old_Gen          thrpt   10      0.396 ±   0.061  MB/sec
-M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.churn.G1_Old_Gen.norm     thrpt   10      2.319 ±   0.328    B/op
-M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.count                     thrpt   10    487.000            counts
-M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.time                      thrpt   10    523.000                ms
-M3ReporterBenchmark.reportHistogramValueSamplesBenchmark                                  thrpt   10    127.358 ±  27.740  ops/ms
-M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.alloc.rate                   thrpt   10   1137.984 ± 277.276  MB/sec
-M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.alloc.rate.norm              thrpt   10   9832.138 ± 746.649    B/op
-M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.churn.G1_Eden_Space          thrpt   10   1165.985 ± 256.119  MB/sec
-M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.churn.G1_Eden_Space.norm     thrpt   10  10082.318 ± 226.966    B/op
-M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.churn.G1_Old_Gen             thrpt   10      0.211 ±   0.038  MB/sec
-M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.churn.G1_Old_Gen.norm        thrpt   10      1.846 ±   0.296    B/op
-M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.count                        thrpt   10    403.000            counts
-M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.time                         thrpt   10    542.000                ms
-M3ReporterBenchmark.reportTimerBenchmark                                                  thrpt   10    512.706 ±  21.351  ops/ms
-M3ReporterBenchmark.reportTimerBenchmark:·gc.alloc.rate                                   thrpt   10   1120.503 ± 224.871  MB/sec
-M3ReporterBenchmark.reportTimerBenchmark:·gc.alloc.rate.norm                              thrpt   10   2408.751 ± 485.159    B/op
-M3ReporterBenchmark.reportTimerBenchmark:·gc.churn.G1_Eden_Space                          thrpt   10   1195.056 ±  53.874  MB/sec
-M3ReporterBenchmark.reportTimerBenchmark:·gc.churn.G1_Eden_Space.norm                     thrpt   10   2567.682 ±  52.447    B/op
-M3ReporterBenchmark.reportTimerBenchmark:·gc.churn.G1_Old_Gen                             thrpt   10      1.210 ±   0.241  MB/sec
-M3ReporterBenchmark.reportTimerBenchmark:·gc.churn.G1_Old_Gen.norm                        thrpt   10      2.601 ±   0.543    B/op
-M3ReporterBenchmark.reportTimerBenchmark:·gc.churn.G1_Survivor_Space                      thrpt   10      2.608 ±   0.744  MB/sec
-M3ReporterBenchmark.reportTimerBenchmark:·gc.churn.G1_Survivor_Space.norm                 thrpt   10      5.597 ±   1.516    B/op
-M3ReporterBenchmark.reportTimerBenchmark:·gc.count                                        thrpt   10    417.000            counts
-M3ReporterBenchmark.reportTimerBenchmark:·gc.time                                         thrpt   10   1299.000                ms
+Benchmark                                                                                      Mode  Cnt      Score      Error    Units
+M3ReporterBenchmark.reportCounterBenchmark                                                    thrpt   10    514.215 ±   34.242   ops/ms
+M3ReporterBenchmark.reportCounterBenchmark:·async                                             thrpt             NaN                 ---
+M3ReporterBenchmark.reportCounterBenchmark:·gc.alloc.rate                                     thrpt   10    437.375 ±   26.826   MB/sec
+M3ReporterBenchmark.reportCounterBenchmark:·gc.alloc.rate.norm                                thrpt   10   1116.034 ±   19.123     B/op
+M3ReporterBenchmark.reportCounterBenchmark:·gc.churn.G1_Eden_Space                            thrpt   10    690.767 ±   50.821   MB/sec
+M3ReporterBenchmark.reportCounterBenchmark:·gc.churn.G1_Eden_Space.norm                       thrpt   10   1762.206 ±   45.887     B/op
+M3ReporterBenchmark.reportCounterBenchmark:·gc.churn.G1_Old_Gen                               thrpt   10      0.019 ±    0.091   MB/sec
+M3ReporterBenchmark.reportCounterBenchmark:·gc.churn.G1_Old_Gen.norm                          thrpt   10      0.045 ±    0.213     B/op
+M3ReporterBenchmark.reportCounterBenchmark:·gc.churn.G1_Survivor_Space                        thrpt   10      6.706 ±    9.252   MB/sec
+M3ReporterBenchmark.reportCounterBenchmark:·gc.churn.G1_Survivor_Space.norm                   thrpt   10     16.765 ±   21.462     B/op
+M3ReporterBenchmark.reportCounterBenchmark:·gc.count                                          thrpt   10    220.000              counts
+M3ReporterBenchmark.reportCounterBenchmark:·gc.time                                           thrpt   10  30423.000                  ms
+M3ReporterBenchmark.reportCounterBenchmark:·threads.alive                                     thrpt   10      5.000 ±    0.001  threads
+M3ReporterBenchmark.reportCounterBenchmark:·threads.daemon                                    thrpt   10      4.000 ±    0.001  threads
+M3ReporterBenchmark.reportCounterBenchmark:·threads.started                                   thrpt   10     37.000             threads
+M3ReporterBenchmark.reportCounterParallelBenchmark                                            thrpt   10   2015.384 ± 2042.141   ops/ms
+M3ReporterBenchmark.reportCounterParallelBenchmark:·async                                     thrpt             NaN                 ---
+M3ReporterBenchmark.reportCounterParallelBenchmark:·gc.alloc.rate                             thrpt   10    246.593 ±  275.848   MB/sec
+M3ReporterBenchmark.reportCounterParallelBenchmark:·gc.alloc.rate.norm                        thrpt   10    284.050 ±    0.129     B/op
+M3ReporterBenchmark.reportCounterParallelBenchmark:·gc.churn.G1_Eden_Space                    thrpt   10    379.818 ±  418.912   MB/sec
+M3ReporterBenchmark.reportCounterParallelBenchmark:·gc.churn.G1_Eden_Space.norm               thrpt   10    440.820 ±   24.887     B/op
+M3ReporterBenchmark.reportCounterParallelBenchmark:·gc.churn.G1_Old_Gen                       thrpt   10      0.061 ±    0.055   MB/sec
+M3ReporterBenchmark.reportCounterParallelBenchmark:·gc.churn.G1_Old_Gen.norm                  thrpt   10      0.089 ±    0.083     B/op
+M3ReporterBenchmark.reportCounterParallelBenchmark:·gc.churn.G1_Survivor_Space                thrpt   10      2.739 ±    1.569   MB/sec
+M3ReporterBenchmark.reportCounterParallelBenchmark:·gc.churn.G1_Survivor_Space.norm           thrpt   10      4.417 ±    3.212     B/op
+M3ReporterBenchmark.reportCounterParallelBenchmark:·gc.count                                  thrpt   10    291.000              counts
+M3ReporterBenchmark.reportCounterParallelBenchmark:·gc.time                                   thrpt   10  58775.000                  ms
+M3ReporterBenchmark.reportCounterParallelBenchmark:·threads.alive                             thrpt   10      8.000 ±    0.001  threads
+M3ReporterBenchmark.reportCounterParallelBenchmark:·threads.daemon                            thrpt   10      7.000 ±    0.001  threads
+M3ReporterBenchmark.reportCounterParallelBenchmark:·threads.started                           thrpt   10     40.000             threads
+M3ReporterBenchmark.reportGaugeBenchmark                                                      thrpt   10    149.579 ±   61.457   ops/ms
+M3ReporterBenchmark.reportGaugeBenchmark:·async                                               thrpt             NaN                 ---
+M3ReporterBenchmark.reportGaugeBenchmark:·gc.alloc.rate                                       thrpt   10    133.842 ±   59.667   MB/sec
+M3ReporterBenchmark.reportGaugeBenchmark:·gc.alloc.rate.norm                                  thrpt   10   1168.126 ±    0.038     B/op
+M3ReporterBenchmark.reportGaugeBenchmark:·gc.churn.G1_Eden_Space                              thrpt   10    216.775 ±  106.813   MB/sec
+M3ReporterBenchmark.reportGaugeBenchmark:·gc.churn.G1_Eden_Space.norm                         thrpt   10   1880.746 ±  108.728     B/op
+M3ReporterBenchmark.reportGaugeBenchmark:·gc.churn.G1_Old_Gen                                 thrpt   10      0.009 ±    0.043   MB/sec
+M3ReporterBenchmark.reportGaugeBenchmark:·gc.churn.G1_Old_Gen.norm                            thrpt   10      0.045 ±    0.214     B/op
+M3ReporterBenchmark.reportGaugeBenchmark:·gc.churn.G1_Survivor_Space                          thrpt   10      1.555 ±    2.526   MB/sec
+M3ReporterBenchmark.reportGaugeBenchmark:·gc.churn.G1_Survivor_Space.norm                     thrpt   10     11.875 ±   16.763     B/op
+M3ReporterBenchmark.reportGaugeBenchmark:·gc.count                                            thrpt   10    161.000              counts
+M3ReporterBenchmark.reportGaugeBenchmark:·gc.time                                             thrpt   10  31911.000                  ms
+M3ReporterBenchmark.reportGaugeBenchmark:·threads.alive                                       thrpt   10      5.000 ±    0.001  threads
+M3ReporterBenchmark.reportGaugeBenchmark:·threads.daemon                                      thrpt   10      4.000 ±    0.001  threads
+M3ReporterBenchmark.reportGaugeBenchmark:·threads.started                                     thrpt   10     37.000             threads
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark                                   thrpt   10     49.933 ±   39.110   ops/ms
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·async                            thrpt             NaN                 ---
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.alloc.rate                    thrpt   10    270.159 ±  211.231   MB/sec
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.alloc.rate.norm               thrpt   10   6064.434 ±    0.281     B/op
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.churn.G1_Eden_Space           thrpt   10    270.268 ±  247.130   MB/sec
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.churn.G1_Eden_Space.norm      thrpt   10   5970.980 ± 1925.316     B/op
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.churn.G1_Old_Gen              thrpt   10      0.201 ±    0.163   MB/sec
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.churn.G1_Old_Gen.norm         thrpt   10      5.936 ±    7.227     B/op
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.churn.G1_Survivor_Space       thrpt   10      3.305 ±    7.621   MB/sec
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.churn.G1_Survivor_Space.norm  thrpt   10     51.805 ±   85.682     B/op
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.count                         thrpt   10    132.000              counts
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·gc.time                          thrpt   10   4772.000                  ms
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·threads.alive                    thrpt   10      5.000 ±    0.001  threads
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·threads.daemon                   thrpt   10      4.000 ±    0.001  threads
+M3ReporterBenchmark.reportHistogramDurationSamplesBenchmark:·threads.started                  thrpt   10     37.000             threads
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark                                      thrpt   10     41.705 ±   45.191   ops/ms
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·async                               thrpt             NaN                 ---
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.alloc.rate                       thrpt   10    291.152 ±  320.494   MB/sec
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.alloc.rate.norm                  thrpt   10   7788.516 ±   19.085     B/op
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.churn.G1_Eden_Space              thrpt   10    319.512 ±  366.795   MB/sec
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.churn.G1_Eden_Space.norm         thrpt   10   8447.524 ±  577.648     B/op
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.churn.G1_Old_Gen                 thrpt   10      0.326 ±    0.239   MB/sec
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.churn.G1_Old_Gen.norm            thrpt   10     10.611 ±    8.406     B/op
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.churn.G1_Survivor_Space          thrpt   10      3.568 ±    6.344   MB/sec
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.churn.G1_Survivor_Space.norm     thrpt   10     84.629 ±   77.853     B/op
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.count                            thrpt   10    165.000              counts
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·gc.time                             thrpt   10   4233.000                  ms
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·threads.alive                       thrpt   10      5.000 ±    0.001  threads
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·threads.daemon                      thrpt   10      4.000 ±    0.001  threads
+M3ReporterBenchmark.reportHistogramValueSamplesBenchmark:·threads.started                     thrpt   10     37.000             threads
+M3ReporterBenchmark.reportTimerBenchmark                                                      thrpt   10    315.832 ±  255.075   ops/ms
+M3ReporterBenchmark.reportTimerBenchmark:·async                                               thrpt             NaN                 ---
+M3ReporterBenchmark.reportTimerBenchmark:·gc.alloc.rate                                       thrpt   10    289.650 ±  234.171   MB/sec
+M3ReporterBenchmark.reportTimerBenchmark:·gc.alloc.rate.norm                                  thrpt   10   1168.070 ±    0.048     B/op
+M3ReporterBenchmark.reportTimerBenchmark:·gc.churn.G1_Eden_Space                              thrpt   10    460.438 ±  381.392   MB/sec
+M3ReporterBenchmark.reportTimerBenchmark:·gc.churn.G1_Eden_Space.norm                         thrpt   10   1845.837 ±   81.841     B/op
+M3ReporterBenchmark.reportTimerBenchmark:·gc.churn.G1_Survivor_Space                          thrpt   10      2.953 ±    4.673   MB/sec
+M3ReporterBenchmark.reportTimerBenchmark:·gc.churn.G1_Survivor_Space.norm                     thrpt   10      9.174 ±   11.454     B/op
+M3ReporterBenchmark.reportTimerBenchmark:·gc.count                                            thrpt   10    199.000              counts
+M3ReporterBenchmark.reportTimerBenchmark:·gc.time                                             thrpt   10  30459.000                  ms
+M3ReporterBenchmark.reportTimerBenchmark:·threads.alive                                       thrpt   10      5.000 ±    0.001  threads
+M3ReporterBenchmark.reportTimerBenchmark:·threads.daemon                                      thrpt   10      4.000 ±    0.001  threads
+M3ReporterBenchmark.reportTimerBenchmark:·threads.started                                     thrpt   10     37.000             threads

--- a/m3/build.gradle
+++ b/m3/build.gradle
@@ -33,6 +33,7 @@ sourceSets {
     jmh {
         java.srcDirs = ['src/jmh/java']
         resources.srcDirs = ['src/jmh/resources']
+
         compileClasspath += sourceSets.main.runtimeClasspath
         compileClasspath += sourceSets.test.runtimeClasspath
     }
@@ -49,7 +50,22 @@ task runJmhTests(type: JavaExec, dependsOn: jmhClasses) {
     args '-e', '.*ScopeImplBenchmark.*'
     args '-rf', 'text'
     args '-rff', resultFile
+
+    // Profile using GC, Threading profilers
     args '-prof', 'gc'
+    args '-prof', 'hs_thr'
+
+    // Profile using async-profiling
+    //
+    // NOTE: For this to work you need to make sure that async-profiler's library is either
+    //          - Available in LD_LIBRARY_PATH (Linux), DYLD_LIBRARY_PATH (Mac)
+    //          - Available in '-Djava.library.path'
+    //          - Explicitly specified with 'async:libPath=</path/libasyncProfiler.so>'
+    args '-prof', 'async:event=cpu;direction=forward;output=flamegraph'
+
+    // Force GC after every iterations, to make sure that one iteration
+    // doesn't affect the other one
+    args '-gc', 'true'
 }
 
 classes.finalizedBy(jmhClasses)

--- a/m3/src/jmh/java/com/uber/m3/tally/m3/M3ReporterBenchmark.java
+++ b/m3/src/jmh/java/com/uber/m3/tally/m3/M3ReporterBenchmark.java
@@ -21,20 +21,34 @@
 package com.uber.m3.tally.m3;
 
 import com.uber.m3.tally.AbstractReporterBenchmark;
-import com.uber.m3.tally.StatsReporter;
+import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 
-public class M3ReporterBenchmark extends AbstractReporterBenchmark {
+public class M3ReporterBenchmark extends AbstractReporterBenchmark<M3Reporter> {
 
     @Override
-    public StatsReporter initReporter() {
+    public M3Reporter bootReporter() {
         SocketAddress socketAddress = new InetSocketAddress("127.0.0.1", 12345);
         return new M3Reporter.Builder(socketAddress)
                 .service("test-service")
                 .commonTags(ImmutableMap.of("env", "test"))
+                .maxQueueSize(Integer.MAX_VALUE)
                 .build();
+    }
+
+    @Override
+    public void shutdownReporter(M3Reporter reporter) {
+        reporter.close();
+
+        try {
+            // This is required to guarantee that reporter shutdowns cleanly
+            // before we start new iteration
+            reporter.awaitTermination(Duration.ofSeconds(300));
+        } catch (InterruptedException e) {
+            // no-op
+        }
     }
 }

--- a/prometheus/build.gradle
+++ b/prometheus/build.gradle
@@ -45,7 +45,22 @@ task runJmhTests(type: JavaExec, dependsOn: jmhClasses) {
     args '-e', '.*ScopeImplBenchmark.*'
     args '-rf', 'text'
     args '-rff', resultFile
+
+    // Profile using GC, Threading profilers
     args '-prof', 'gc'
+    args '-prof', 'hs_thr'
+
+    // Profile using async-profiling
+    //
+    // NOTE: For this to work you need to make sure that async-profiler's library is either
+    //          - Available in LD_LIBRARY_PATH (Linux), DYLD_LIBRARY_PATH (Mac)
+    //          - Available in '-Djava.library.path'
+    //          - Explicitly specified with 'async:libPath=</path/libasyncProfiler.so>'
+    args '-prof', 'async:event=cpu;direction=forward;output=flamegraph'
+
+    // Force GC after every iterations, to make sure that one iteration
+    // doesn't affect the other one
+    args '-gc', 'true'
 }
 
 classes.finalizedBy(jmhClasses)

--- a/prometheus/src/jmh/java/com/uber/m3/tally/experimental/prometheus/PrometheusReporterBenchmark.java
+++ b/prometheus/src/jmh/java/com/uber/m3/tally/experimental/prometheus/PrometheusReporterBenchmark.java
@@ -21,15 +21,19 @@
 package com.uber.m3.tally.experimental.prometheus;
 
 import com.uber.m3.tally.AbstractReporterBenchmark;
-import com.uber.m3.tally.StatsReporter;
 import io.prometheus.client.CollectorRegistry;
 
-public class PrometheusReporterBenchmark extends AbstractReporterBenchmark {
+public class PrometheusReporterBenchmark extends AbstractReporterBenchmark<PrometheusReporter> {
 
     @Override
-    public StatsReporter initReporter() {
+    public PrometheusReporter bootReporter() {
         return PrometheusReporter.builder()
                 .registry(CollectorRegistry.defaultRegistry)
                 .build();
+    }
+
+    @Override
+    public void shutdownReporter(PrometheusReporter reporter) {
+        reporter.close();
     }
 }

--- a/prometheus/src/jmh/java/com/uber/m3/tally/experimental/prometheus/PrometheusReporterBenchmark.java
+++ b/prometheus/src/jmh/java/com/uber/m3/tally/experimental/prometheus/PrometheusReporterBenchmark.java
@@ -32,8 +32,4 @@ public class PrometheusReporterBenchmark extends AbstractReporterBenchmark<Prome
                 .build();
     }
 
-    @Override
-    public void shutdownReporter(PrometheusReporter reporter) {
-        reporter.close();
-    }
 }

--- a/statsd/build.gradle
+++ b/statsd/build.gradle
@@ -45,7 +45,22 @@ task runJmhTests(type: JavaExec, dependsOn: jmhClasses) {
     args '-e', '.*ScopeImplBenchmark.*'
     args '-rf', 'text'
     args '-rff', resultFile
+
+    // Profile using GC, Threading profilers
     args '-prof', 'gc'
+    args '-prof', 'hs_thr'
+
+    // Profile using async-profiling
+    //
+    // NOTE: For this to work you need to make sure that async-profiler's library is either
+    //          - Available in LD_LIBRARY_PATH (Linux), DYLD_LIBRARY_PATH (Mac)
+    //          - Available in '-Djava.library.path'
+    //          - Explicitly specified with 'async:libPath=</path/libasyncProfiler.so>'
+    args '-prof', 'async:event=cpu;direction=forward;output=flamegraph'
+
+    // Force GC after every iterations, to make sure that one iteration
+    // doesn't affect the other one
+    args '-gc', 'true'
 }
 
 classes.finalizedBy(jmhClasses)

--- a/statsd/src/jmh/java/com/uber/m3/tally/statsd/StatsdReporterBenchmark.java
+++ b/statsd/src/jmh/java/com/uber/m3/tally/statsd/StatsdReporterBenchmark.java
@@ -23,12 +23,16 @@ package com.uber.m3.tally.statsd;
 import com.timgroup.statsd.NonBlockingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import com.uber.m3.tally.AbstractReporterBenchmark;
-import com.uber.m3.tally.StatsReporter;
 
-public class StatsdReporterBenchmark extends AbstractReporterBenchmark {
+public class StatsdReporterBenchmark extends AbstractReporterBenchmark<StatsdReporter> {
     @Override
-    public StatsReporter initReporter() {
+    public StatsdReporter bootReporter() {
         StatsDClient statsd = new NonBlockingStatsDClient("statsd-test", "localhost", 1235);
         return new StatsdReporter(statsd);
+    }
+
+    @Override
+    public void shutdownReporter(StatsdReporter reporter) {
+        reporter.close();
     }
 }

--- a/statsd/src/jmh/java/com/uber/m3/tally/statsd/StatsdReporterBenchmark.java
+++ b/statsd/src/jmh/java/com/uber/m3/tally/statsd/StatsdReporterBenchmark.java
@@ -25,14 +25,11 @@ import com.timgroup.statsd.StatsDClient;
 import com.uber.m3.tally.AbstractReporterBenchmark;
 
 public class StatsdReporterBenchmark extends AbstractReporterBenchmark<StatsdReporter> {
+
     @Override
     public StatsdReporter bootReporter() {
         StatsDClient statsd = new NonBlockingStatsDClient("statsd-test", "localhost", 1235);
         return new StatsdReporter(statsd);
     }
 
-    @Override
-    public void shutdownReporter(StatsdReporter reporter) {
-        reporter.close();
-    }
 }


### PR DESCRIPTION
Current implementation of Tally relies on `BlockingLinkedQueue` making each reporting of the metric to acquire lock while adding the metrics to the processing queue, contending w/ the `M3Processor` trying to read from the same queue.

Since there are hardly any good reasons for us to rely on the blocking queue, i've refactored `M3Reporter` to rely on non-blocking lock-free queue implementation (`ConcurrentLinkedQueue`).

However to preserve previous semantic of `M3Reporter.Processor` being parked in case there are no currently metrics enqueued for processing, as well as it being notified whenever there are new metrics in the queue, `Condition` is being used to notify and un-park processors.