### PR TITLE
Make the threads created by M3Reporter be daemon threads

### DIFF
--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -519,7 +519,7 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
         return new ThreadFactory() {
             @Override
             public Thread newThread(Runnable r) {
-                return new Thread(r, String.format("m3-reporter-%d", processorThreadCounter.getAndIncrement()));
+                return new Thread(r, String.format("m3-reporter-%d", processorThreadCounter.getAndIncrement())).setDaemon(true);
             }
         };
     }


### PR DESCRIPTION
Fixing https://github.com/uber-java/tally/issues/102