### PR TITLE
Upgrade gradle version to 6.9.2

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,34 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+    - name: Build with Gradle
+      uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
+      with:
+        arguments: build

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 8
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '8'
         distribution: 'temurin'
     - name: Build with Gradle
       uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,3 +32,8 @@ jobs:
       uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
       with:
         arguments: build
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v1
+      if: always()
+      with:
+        files: "test-results/**/*.xml"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,8 +32,3 @@ jobs:
       uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
       with:
         arguments: build
-    - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1
-      if: always()
-      with:
-        files: "test-results/**/*.xml"

--- a/build.gradle
+++ b/build.gradle
@@ -169,9 +169,10 @@ subprojects {
 
 ext."signing.secretKeyRingFile" = "ci/${ext.secretKeyRingFileName}"
 
-task wrapper(type: Wrapper) {
+
+wrapper {
     // Gradle version 4+ required for JMH benchmarking, otherwise v3.5+ is sufficient
-    gradleVersion = '4.0'
+    gradleVersion = '6.9'
 }
 
 // --------------------------------------
@@ -183,9 +184,9 @@ coveralls {
 
 task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
     dependsOn = subprojects.test
-    sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
-    classDirectories =  files(subprojects.sourceSets.main.output.classesDirs)
-    executionData = files(subprojects.jacocoTestReport.executionData)
+    sourceDirectories.setFrom(files(subprojects.sourceSets.main.allSource.srcDirs))
+    classDirectories.setFrom(files(subprojects.sourceSets.main.output.classesDirs))
+    executionData.setFrom(files(subprojects.jacocoTestReport.executionData))
 
     reports {
         xml.enabled = true

--- a/core/src/test/java/com/uber/m3/tally/BucketPairImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/BucketPairImplTest.java
@@ -73,6 +73,7 @@ public class BucketPairImplTest {
             expectedPairs,
             BucketPairImpl.bucketPairs(ValueBuckets.linear(0, 50, 3))
         );
+        throw new RuntimeException("amainsd: intentional");
     }
 
     @Test

--- a/core/src/test/java/com/uber/m3/tally/BucketPairImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/BucketPairImplTest.java
@@ -73,7 +73,6 @@ public class BucketPairImplTest {
             expectedPairs,
             BucketPairImpl.bucketPairs(ValueBuckets.linear(0, 50, 3))
         );
-        throw new RuntimeException("amainsd: intentional");
     }
 
     @Test

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Fri Dec 25 03:30:51 CET 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Just some hygiene--we're a full 3 major versions behind at this point. 

Notes: cant go to 7.x just yet; we have some deprecated things to fix up. Doing this step wise (will go to 7.x in a subsequent PR, probably).