### PR TITLE
Check scope existence lock free first

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -42,8 +42,15 @@ task runJmhTests(type: JavaExec, dependsOn: jmhClasses) {
     args '-rff', resultFile
 
     // Profile using GC, Threading profilers
-    args '-prof', 'gc'
-    args '-prof', 'hs_thr'
+    if (project.properties.get('busegc', 'true') == 'true') {
+        args '-prof', 'gc'
+        args '-prof', 'hs_thr'
+
+        // Force GC after every iterations, to make sure that one iteration
+        // doesn't affect the other one
+        args '-gc', 'true'
+    }
+
 
     // Profile using async-profiling
     //
@@ -51,11 +58,11 @@ task runJmhTests(type: JavaExec, dependsOn: jmhClasses) {
     //          - Available in LD_LIBRARY_PATH (Linux), DYLD_LIBRARY_PATH (Mac)
     //          - Available in '-Djava.library.path'
     //          - Explicitly specified with 'async:libPath=</path/libasyncProfiler.so>'
-    args '-prof', 'async:event=cpu;direction=forward;output=flamegraph'
+    args '-prof', project.properties.get('bprof', 'async:event=cpu;direction=forward;output=flamegraph')
 
-    // Force GC after every iterations, to make sure that one iteration
-    // doesn't affect the other one
-    args '-gc', 'true'
+    args '-bm', project.properties.get('bm', 'thrpt')
+    args '-t', project.properties.get('bthreads', '1')
+    args 'com.uber.m3.tally.' + project.properties.get('benchclass', '')
 }
 
 classes.finalizedBy(jmhClasses)

--- a/core/jmhFixtures.gradle
+++ b/core/jmhFixtures.gradle
@@ -54,4 +54,8 @@ dependencies {
     jmhFixturesUsageCompile project(project.path)
     jmhFixturesCompile('org.openjdk.jmh:jmh-core:1.27')
     jmhFixturesCompile('org.openjdk.jmh:jmh-generator-annprocess:1.27')
+
+    if (project.gradle.gradleVersion > '5') {
+        jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:1.27")
+    }
 }

--- a/core/src/jmh/java/com/uber/m3/tally/ScopeImplConcurrent.java
+++ b/core/src/jmh/java/com/uber/m3/tally/ScopeImplConcurrent.java
@@ -1,0 +1,53 @@
+package com.uber.m3.tally;
+
+import com.uber.m3.util.Duration;
+import com.uber.m3.util.ImmutableMap;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(value = 2, jvmArgsAppend = { "-server", "-XX:+UseG1GC" })
+public class ScopeImplConcurrent {
+    private static String KEYS[] = new String[]{
+        " ", "0", "@", "P",
+    };
+
+    @Benchmark
+    public void hotkeyLockContention(Blackhole bh, BenchmarkState state) {
+        ImmutableMap<String, String> common = new ImmutableMap.Builder<String, String>().build();
+        for (int i = 0; i < 10000; i++) {
+
+            for (String key : KEYS) {
+                Scope scope = state.scope.computeSubscopeIfAbsent(key, common);
+                assert scope != null;
+                bh.consume(scope);
+            }
+        }
+    }
+
+    @State(org.openjdk.jmh.annotations.Scope.Benchmark)
+    public static class BenchmarkState {
+
+        private ScopeImpl scope;
+
+        @Setup
+        public void setup() {
+            this.scope =
+                    (ScopeImpl) new RootScopeBuilder()
+                            .reporter(new TestStatsReporter())
+                            .reportEvery(Duration.MAX_VALUE);
+
+            for (String key : KEYS) {
+                scope.computeSubscopeIfAbsent(key, new ImmutableMap.Builder<String, String>().build());
+            }
+        }
+
+        @TearDown
+        public void teardown() {
+            scope.close();
+        }
+    }
+}

--- a/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
@@ -101,6 +101,7 @@ class ScopeImpl implements Scope {
         );
     }
 
+
     @Override
     public Scope tagged(Map<String, String> tags) {
         return subScopeHelper(prefix, tags);
@@ -280,15 +281,25 @@ class ScopeImpl implements Scope {
 
         String key = keyForPrefixedStringMap(prefix, mergedTags);
 
+        return computeSubscopeIfAbsent(key, mergedTags);
+    }
+
+    // This method must only be called on unit tests or benchmarks
+    protected Scope computeSubscopeIfAbsent(String key, ImmutableMap<String, String> mergedTags) {
+        Scope scope = registry.subscopes.get(key);
+        if (scope != null) {
+            return scope;
+        }
+
         return registry.subscopes.computeIfAbsent(
-            key,
-            (k) -> new ScopeBuilder(scheduler, registry)
-                .reporter(reporter)
-                .prefix(prefix)
-                .separator(separator)
-                .tags(mergedTags)
-                .defaultBuckets(defaultBuckets)
-                .build()
+                key,
+                (k) -> new ScopeBuilder(scheduler, registry)
+                        .reporter(reporter)
+                        .prefix(prefix)
+                        .separator(separator)
+                        .tags(mergedTags)
+                        .defaultBuckets(defaultBuckets)
+                        .build()
         );
     }
 


### PR DESCRIPTION
We have found that for java applications running on big machines (>8 cores) we start to see sudden spikes in latency. For instance a 32 core service gets a 100 ms spike which affect our p99.9.

By calling .get() before computeIfAbsent() we are able to reduce the impact of this (we can't completely remove it because we could still be allocating new keys).

We added a benchmark to demonstrate this. The 32 thread results are as follows:

**Before the fix**
<img width="1093" alt="Screenshot 2022-12-22 at 9 39 58 AM" src="https://user-images.githubusercontent.com/3793727/209203267-0fcb84a9-fb99-46a3-a691-ac5887033246.png">

**After the fix**
<img width="1113" alt="Screenshot 2022-12-22 at 9 53 03 AM" src="https://user-images.githubusercontent.com/3793727/209203269-5a1570d5-0d1d-43a2-b6a5-a61660063b55.png">
