### PR TITLE
Revert "Release v0.12.0 (#111)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ configurations.archives.artifacts.clear()
 
 allprojects {
     group = 'com.uber.m3'
-    version = '0.12.0'
+    version = '0.11.1'
 
     apply plugin: 'java'
     apply plugin: 'maven'


### PR DESCRIPTION
This reverts commit 946455dd62eaaf28ce5bba6ce18f36937557eec5.

Reverting this for now (v0.12.0 hasn't been released to Maven yet) because `:tally-core:test` fails after https://github.com/uber-java/tally/pull/110.