### PR TITLE
Fix shadowed prefix variable

### DIFF
--- a/core/src/jmh/java/com/uber/m3/tally/ScopeImplConcurrent.java
+++ b/core/src/jmh/java/com/uber/m3/tally/ScopeImplConcurrent.java
@@ -21,7 +21,7 @@ public class ScopeImplConcurrent {
         for (int i = 0; i < 10000; i++) {
 
             for (String key : KEYS) {
-                Scope scope = state.scope.computeSubscopeIfAbsent(key, common);
+                Scope scope = state.scope.computeSubscopeIfAbsent("prefix", key, common);
                 assert scope != null;
                 bh.consume(scope);
             }
@@ -41,7 +41,7 @@ public class ScopeImplConcurrent {
                             .reportEvery(Duration.MAX_VALUE);
 
             for (String key : KEYS) {
-                scope.computeSubscopeIfAbsent(key, new ImmutableMap.Builder<String, String>().build());
+                scope.computeSubscopeIfAbsent("prefix", key, new ImmutableMap.Builder<String, String>().build());
             }
         }
 

--- a/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
@@ -281,11 +281,11 @@ class ScopeImpl implements Scope {
 
         String key = keyForPrefixedStringMap(prefix, mergedTags);
 
-        return computeSubscopeIfAbsent(key, mergedTags);
+        return computeSubscopeIfAbsent(prefix, key, mergedTags);
     }
 
     // This method must only be called on unit tests or benchmarks
-    protected Scope computeSubscopeIfAbsent(String key, ImmutableMap<String, String> mergedTags) {
+    protected Scope computeSubscopeIfAbsent(String prefix, String key, ImmutableMap<String, String> mergedTags) {
         Scope scope = registry.subscopes.get(key);
         if (scope != null) {
             return scope;


### PR DESCRIPTION
#110 Introduced a bug because I didn't realize that the parameter prefix shadows the class variable. Therefore, this was causing tests to fail.