### PR TITLE
Use Double.Infinity for upper and lower Value buckets

### DIFF
--- a/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
@@ -130,23 +130,33 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
     }
 
     private Duration getUpperBoundDurationForBucket(int bucketIndex) {
-        return bucketIndex < specification.getDurationUpperBounds().size() ? specification.getDurationUpperBounds().get(bucketIndex) : Duration.MAX_VALUE;
+        return bucketIndex < specification.getDurationUpperBounds().size()
+                ? specification.getDurationUpperBounds().get(bucketIndex)
+                : Duration.MAX_VALUE;
     }
 
     private Duration getLowerBoundDurationForBucket(int bucketIndex) {
-        return bucketIndex == 0 ? Duration.MIN_VALUE : specification.getDurationUpperBounds().get(bucketIndex - 1);
+        return bucketIndex == 0
+                ? Duration.MIN_VALUE
+                : specification.getDurationUpperBounds().get(bucketIndex - 1);
     }
 
     private double getUpperBoundValueForBucket(int bucketIndex) {
-        return bucketIndex < specification.getValueUpperBounds().size() ? specification.getValueUpperBounds().get(bucketIndex) : Double.MAX_VALUE;
+        return bucketIndex < specification.getValueUpperBounds().size()
+                ? specification.getValueUpperBounds().get(bucketIndex)
+                : Double.POSITIVE_INFINITY;
     }
 
     private double getLowerBoundValueForBucket(int bucketIndex) {
-        return bucketIndex == 0 ? Double.MIN_VALUE : specification.getValueUpperBounds().get(bucketIndex - 1);
+        return bucketIndex == 0
+                ? Double.NEGATIVE_INFINITY
+                : specification.getValueUpperBounds().get(bucketIndex - 1);
     }
 
     private long getCounterValue(int index) {
-        return bucketCounters[index] != null ? bucketCounters[index].value() : 0;
+        return bucketCounters[index] != null
+                ? bucketCounters[index].value()
+                : 0;
     }
 
     // NOTE: Only used in testing
@@ -155,9 +165,10 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
             return null;
         }
 
-        Map<Double, Long> values = new HashMap<>(bucketCounters.length, 1);
+        int length = bucketCounters.length;
+        Map<Double, Long> values = new HashMap<>(length, 1);
 
-        for (int i = 0; i < bucketCounters.length; ++i) {
+        for (int i = 0; i < length; ++i) {
             values.put(getUpperBoundValueForBucket(i), getCounterValue(i));
         }
 
@@ -169,9 +180,10 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
             return null;
         }
 
-        Map<Duration, Long> durations = new HashMap<>(bucketCounters.length, 1);
+        int length = bucketCounters.length;
+        Map<Duration, Long> durations = new HashMap<>(length, 1);
 
-        for (int i = 0; i < bucketCounters.length; ++i) {
+        for (int i = 0; i < length; ++i) {
             durations.put(getUpperBoundDurationForBucket(i), getCounterValue(i));
         }
 

--- a/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
@@ -35,12 +35,12 @@ public class ValueBuckets extends AbstractBuckets<Double> {
 
     @Override
     public double getValueLowerBoundFor(int bucketIndex) {
-        return bucketIndex == 0 ? Double.MIN_VALUE : buckets.get(bucketIndex - 1);
+        return bucketIndex == 0 ? Double.NEGATIVE_INFINITY : buckets.get(bucketIndex - 1);
     }
 
     @Override
     public double getValueUpperBoundFor(int bucketIndex) {
-        return bucketIndex < buckets.size() ? buckets.get(bucketIndex) : Double.MAX_VALUE;
+        return bucketIndex < buckets.size() ? buckets.get(bucketIndex) : Double.POSITIVE_INFINITY;
     }
 
     @Override

--- a/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/M3Reporter.java
@@ -320,12 +320,12 @@ public class M3Reporter implements StatsReporter, AutoCloseable {
         return metricTag;
     }
 
-    private String valueBucketString(double bucketBound) {
-        if (bucketBound == Double.MAX_VALUE) {
+    String valueBucketString(double bucketBound) {
+        if (bucketBound == Double.POSITIVE_INFINITY) {
             return "infinity";
         }
 
-        if (bucketBound == -Double.MAX_VALUE) {
+        if (bucketBound == Double.NEGATIVE_INFINITY) {
             return "-infinity";
         }
 

--- a/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
+++ b/m3/src/test/java/com/uber/m3/tally/m3/M3ReporterTest.java
@@ -38,6 +38,7 @@ import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
+import org.hamcrest.CoreMatchers;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -52,9 +53,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 // TODO add tests to validate proper shutdown
@@ -548,5 +551,24 @@ public class M3ReporterTest {
         }
 
         assertEquals(expectedMetricsCount, metrics.size());
+    }
+
+    @Test
+    public void valueBuckets() {
+        M3Reporter reporter = new M3Reporter.Builder(socketAddress)
+                .service("test")
+                .env("test")
+                .build();
+
+        String res = reporter.valueBucketString(0);
+        assertThat("0.000000", is(res));
+        res = reporter.valueBucketString(Double.NEGATIVE_INFINITY);
+        assertThat("-infinity", is(res));
+        res = reporter.valueBucketString(Double.NEGATIVE_INFINITY + 42);
+        assertThat("-infinity", is(res));
+        res = reporter.valueBucketString(Double.POSITIVE_INFINITY);
+        assertThat("infinity", is(res));
+        res = reporter.valueBucketString(Double.POSITIVE_INFINITY + 42);
+        assertThat("infinity", is(res));
     }
 }


### PR DESCRIPTION
Using `Double.POSITIVE_INFINITY` and `Double.NEGATIVE_INFINITY` instead of `Double.MAX_VALUE` and `DOUBLE.MIN_VALUE`

N.B.
This PR doesn't attempt to solve the problem completely. After this change is applied the following scenario is still possible:
Assume we have the buckets: `(-Inf, 10), [10, 20), [20, +Inf)`
When we attempt to find a bucket for `10 - Double.MIN_VALUE` it can either be placed into the first or the second bucket. And this is not a problem. We're not trying to optimize for extremely high accuracy here.
