### PR TITLE
Fix Snapshots creation

### DIFF
--- a/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
@@ -23,6 +23,7 @@ package com.uber.m3.tally;
 import com.uber.m3.util.ImmutableMap;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -172,7 +173,11 @@ class ScopeImpl implements Scope, TestScope {
     public Snapshot snapshot() {
         Snapshot snap = new SnapshotImpl();
 
-        for (ScopeImpl subscope : registry.subscopes.values()) {
+        ArrayList<ScopeImpl> scopes = new ArrayList<>();
+        scopes.add(this);
+        scopes.addAll(registry.subscopes.values());
+
+        for (ScopeImpl subscope : scopes) {
             ImmutableMap<String, String> tags = new ImmutableMap.Builder<String, String>()
                     .putAll(this.tags)
                     .putAll(subscope.tags)

--- a/core/src/test/java/com/uber/m3/tally/TestScopeTest.java
+++ b/core/src/test/java/com/uber/m3/tally/TestScopeTest.java
@@ -47,18 +47,26 @@ public class TestScopeTest {
 
         testScope.tagged(tags).counter("counter").inc(1);
 
+        testScope.counter("untagged_counter").inc(1);
+
         Snapshot snapshot = testScope.snapshot();
         assertNotNull(snapshot);
 
         Map<ScopeKey, CounterSnapshot> counters = snapshot.counters();
         assertNotNull(counters);
-        assertEquals(1, counters.size());
+        assertEquals(2, counters.size());
 
         CounterSnapshot counterSnapshot = counters.get(new ScopeKey("counter", tags));
         assertNotNull(counterSnapshot);
 
         assertEquals("counter", counterSnapshot.name());
         assertEquals(tags, counterSnapshot.tags());
+        assertEquals(1, counterSnapshot.value());
+
+        counterSnapshot = counters.get(new ScopeKey("untagged_counter", ImmutableMap.EMPTY));
+        assertNotNull(counterSnapshot);
+        assertEquals("untagged_counter", counterSnapshot.name());
+        assertEquals(ImmutableMap.EMPTY, counterSnapshot.tags());
         assertEquals(1, counterSnapshot.value());
     }
 


### PR DESCRIPTION
https://github.com/uber-java/tally/pull/120 has a bug where the `Snapshot` only includes the subscopes and not the metrics on the current scope. This fixes the `snapshot` method to include metrics on the current scope as well.