### PR TITLE
Fix issue where histogram snapshot mutates its state

### DIFF
--- a/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/HistogramImpl.java
@@ -145,8 +145,8 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
         return bucketIndex == 0 ? Double.MIN_VALUE : specification.getValueUpperBounds().get(bucketIndex - 1);
     }
 
-    private long getCounterValue(int index) {
-        return bucketCounters[index] != null ? bucketCounters[index].value() : 0;
+    private long snapshotCounterValue(int index) {
+        return bucketCounters[index] != null ? bucketCounters[index].snapshot() : 0;
     }
 
     // NOTE: Only used in testing
@@ -158,7 +158,7 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
         Map<Double, Long> values = new HashMap<>(bucketCounters.length, 1);
 
         for (int i = 0; i < bucketCounters.length; ++i) {
-            values.put(getUpperBoundValueForBucket(i), getCounterValue(i));
+            values.put(getUpperBoundValueForBucket(i), snapshotCounterValue(i));
         }
 
         return values;
@@ -172,7 +172,7 @@ class HistogramImpl extends MetricBase implements Histogram, StopwatchRecorder {
         Map<Duration, Long> durations = new HashMap<>(bucketCounters.length, 1);
 
         for (int i = 0; i < bucketCounters.length; ++i) {
-            durations.put(getUpperBoundDurationForBucket(i), getCounterValue(i));
+            durations.put(getUpperBoundDurationForBucket(i), snapshotCounterValue(i));
         }
 
         return durations;

--- a/core/src/test/java/com/uber/m3/tally/HistogramImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/HistogramImplTest.java
@@ -218,6 +218,28 @@ public class HistogramImplTest {
     }
 
     @Test
+    public void snapshotValuesIsIdempotent() {
+        ValueBuckets buckets = ValueBuckets.custom(0, 10);
+
+        histogram =
+                new HistogramImpl(
+                        scope,
+                        "",
+                        null,
+                        buckets
+                );
+
+        histogram.recordValue(5);
+
+        Map<Double, Long> snapshot = histogram.snapshotValues();
+        assertEquals(1, snapshot.get(10D).longValue());
+
+        // snapshot again to ensure the first snapshot didn't mutate internal state
+        snapshot = histogram.snapshotValues();
+        assertEquals(1, snapshot.get(10D).longValue());
+    }
+
+    @Test
     public void snapshotDurations() {
         Buckets buckets = DurationBuckets.linear(Duration.ZERO, Duration.ofMillis(10), 5);
 
@@ -246,5 +268,27 @@ public class HistogramImplTest {
         expectedMap.put(Duration.MAX_VALUE, 5L);
 
         assertEquals(expectedMap, histogram.snapshotDurations());
+    }
+
+    @Test
+    public void snapshotDurationsIsIdempotent() {
+        DurationBuckets buckets = DurationBuckets.custom(Duration.ofMillis(0), Duration.ofMillis(10));
+
+        histogram =
+                new HistogramImpl(
+                        scope,
+                        "",
+                        null,
+                        buckets
+                );
+
+        histogram.recordDuration(Duration.ofMillis(5));
+
+        Map<Duration, Long> snapshot = histogram.snapshotDurations();
+        assertEquals(1, snapshot.get(Duration.ofMillis(10)).longValue());
+
+        // snapshot again to ensure the first snapshot didn't mutate internal state
+        snapshot = histogram.snapshotDurations();
+        assertEquals(1, snapshot.get(Duration.ofMillis(10)).longValue());
     }
 }


### PR DESCRIPTION
The current `HistogramImpl#snapshot` implementation ultimately calls `CounterImpl#value`, which mutates its state. Instead, this PR changes the call to `#snapshot`.