### PR TITLE
Improve components that are used to unit test instrumentation logic

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -25,14 +25,13 @@ To run the JMH benchmark tests:
 ./gradlew runJmhTests
 ```
 
-By default, the benchmark test results are writen to `benchmark-tests.txt`.
-Use `output` input parameter to configure the output path.
+By default, the benchmark test results are written to `benchmark-tests.txt`.
+Use the `output` input parameter to configure the output path.
 E.g. the following command will run the benchmark tests for `tally-prometheus` sub-project and store 
 the results to `custom/path/result.txt`.  
 ```bash
 ./gradlew :tally-prometheus:runJmhTests -Poutput="custom/path/result.txt"
 ``` 
-
 
 By default, the build does *not* compile Thrift files to generate sources. If you make changes to Thrift files and need
 regenerate sources, make sure you have thrift 0.9.x installed and build with the `genThrift` property set, e.g.
@@ -48,17 +47,16 @@ track [issues](https://help.github.com/articles/about-issues/) and create
 If you have not contributed to the project before, please add your details to the `developers`
 section in the top-level [build file](build.gradle).
 
-### Encypting for Travis
+### Encrypting for Travis
 In order to pass secrets to Travis securely for authentication and signing, we need to encrypt them
 first before checking in. The full documentation [here](https://docs.travis-ci.com/user/encryption-keys/)
 for encrypting keys, and [here](https://docs.travis-ci.com/user/encrypting-files/) for encrypting files.
 
 These are the secrets that need to be passed:
 1. [OSSRH](http://central.sonatype.org/pages/ossrh-guide.html) **username** and **password**. These are
-the credentials used to upload artifacts to the Sonatype Nexus Repository, which is used to sync to
-Maven Central
-1. Signing **key ID**, **password**, and **secret key ring file**. These three are used to sign
-artifacts that get created, which is a requirement in order to upload to Maven Central.
+   the credentials used to upload artifacts to the Sonatype Nexus Repository, which is used to sync to Maven Central.
+2. Signing **key ID**, **password**, and **secret key ring file**. These three are used to sign artifacts that get
+   created, which is a requirement in order to upload to Maven Central.
 
 In order to pass these along, first login to Travis:
 ```bash

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ Fast, buffered, hierarchical stats collection in Java. [Go here](https://github.
 
 ## Abstract
 
-Tally provides a common interface for emitting metrics, while letting you not worry about the velocity of metrics emission.
+Tally provides a common interface for emitting metrics, while letting you not worry about the velocity of metrics
+emission.
 
-By default it buffers counters, gauges and histograms at a specified interval but does not buffer timer values.  This is primarily so timer values can have all their values sampled if desired and if not they can be sampled as summaries or histograms independently by a reporter.
+By default, it buffers counters, gauges and histograms at a specified interval but does not buffer timer values. This is
+primarily so timer values can have all their values sampled if desired and if not they can be sampled as summaries or
+histograms independently by a reporter.
 
 ## Structure
 
@@ -14,7 +17,7 @@ By default it buffers counters, gauges and histograms at a specified interval bu
 - **Metrics**: Counters, Gauges, Timers and Histograms.
 - **Reporter**: Implemented by you. Accepts aggregated values from the scope. Forwards the aggregated values to your metrics ingestion pipeline.
 
-### Acquire a Scope
+### Create a `Scope`
 
 ```java
 // Implement as you will
@@ -22,12 +25,12 @@ StatsReporter reporter = new MyStatsReporter();
 
 Map<String, String> tags = new HashMap<>(2, 1);
 tags.put("dc", "east-1");
-tags.put("type", "master");
+tags.put("type","leader");
 
 Scope scope = new RootScopeBuilder()
     .reporter(reporter)
     .tags(tags)
-    .reportEvery(Duration.ofSeconds(1))
+    .reportEvery(Duration.ofSeconds(1));
 ```
 
 ### Get/Create a metric; use it
@@ -43,27 +46,29 @@ queueGauge.update(42);
 
 Use one of the inbuilt reporters or implement your own using the `StatsReporter` interface.
 
-## Example Usage
+## Usage examples
 
 Run the example by running:
 ```bash
 $ ./gradlew run
 ```
+
 This runs the `PrintStatsReporterExample` class in the `tally-example` project.
 
-## Artifacts Published
+## Artifacts publishing
 
 All artifacts are published under the group `com.uber.m3`.
 
-1. `tally-m3`: The tally M3 reporter
-1. `tally-statsd`: The tally StatsD reporter
-1. `tally-core`: tally core functionality that includes interfaces and utilities to report metrics to M3
-1. `tally-example`: Example usages with different reporters
-1. `tally-prometheus`: The tally Prometheus reporter (experimental; see prometheus/README.md)
+1. `tally-m3`: The tally M3 reporter.
+1. `tally-statsd`: The tally StatsD reporter.
+1. `tally-core`: The tally core functionality that includes interfaces and utilities to report metrics to M3.
+1. `tally-example`: Usage examples with different reporters.
+1. `tally-prometheus`: The tally Prometheus reporter (experimental; see prometheus/README.md).
 
 ## Versioning
-We follow semantic versioning outlined [here](http://semver.org/spec/v2.0.0.html). In summary,
-given a version of MAJOR.MINOR.PATCH (e.g. 1.2.0):
+
+We follow semantic versioning outlined [here](http://semver.org/spec/v2.0.0.html). In summary, given a version of
+MAJOR.MINOR.PATCH (e.g. 1.2.0):
 
 - MAJOR version changes are breaking changes to the public API
 - MINOR version changes are backwards-compatible changes that include new functionality

--- a/core/src/main/java/com/uber/m3/tally/CapableOf.java
+++ b/core/src/main/java/com/uber/m3/tally/CapableOf.java
@@ -29,8 +29,8 @@ public class CapableOf implements Capabilities {
     public static final CapableOf REPORTING = new CapableOf(true, false);
     public static final CapableOf REPORTING_TAGGING = new CapableOf(true, true);
 
-    private boolean reporting;
-    private boolean tagging;
+    private final boolean reporting;
+    private final boolean tagging;
 
     public CapableOf(boolean reporting, boolean tagging) {
         this.reporting = reporting;
@@ -69,8 +69,8 @@ public class CapableOf implements Capabilities {
     public int hashCode() {
         int code = 0;
 
-        code = 31 * code + new Boolean(reporting).hashCode();
-        code = 31 * code + new Boolean(tagging).hashCode();
+        code = 31 * code + Boolean.valueOf(reporting).hashCode();
+        code = 31 * code + Boolean.valueOf(tagging).hashCode();
 
         return code;
     }

--- a/core/src/main/java/com/uber/m3/tally/CounterSnapshotImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/CounterSnapshotImpl.java
@@ -28,9 +28,9 @@ import java.util.Map;
  * Default implementation of a {@link CounterSnapshot}.
  */
 class CounterSnapshotImpl implements CounterSnapshot {
-    private String name;
-    private ImmutableMap<String, String> tags;
-    private long value;
+    private final String name;
+    private final ImmutableMap<String, String> tags;
+    private final long value;
 
     CounterSnapshotImpl(String name, ImmutableMap<String, String> tags, long value) {
         this.name = name;

--- a/core/src/main/java/com/uber/m3/tally/GaugeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/GaugeImpl.java
@@ -29,10 +29,10 @@ import java.util.concurrent.atomic.AtomicLong;
  * Default implementation of a {@link Gauge}.
  */
 class GaugeImpl extends MetricBase implements Gauge, Reportable {
-    private AtomicBoolean updated = new AtomicBoolean(false);
-    private AtomicLong curr = new AtomicLong(0);
+    private final AtomicBoolean updated = new AtomicBoolean(false);
+    private final AtomicLong curr = new AtomicLong(0);
 
-    protected GaugeImpl(ScopeImpl scope, String fqn) {
+    GaugeImpl(ScopeImpl scope, String fqn) {
         super(fqn);
 
         scope.addToReportingQueue(this);
@@ -44,10 +44,6 @@ class GaugeImpl extends MetricBase implements Gauge, Reportable {
         updated.set(true);
     }
 
-    double value() {
-        return Double.longBitsToDouble(curr.get());
-    }
-
     @Override
     public void report(ImmutableMap<String, String> tags, StatsReporter reporter) {
         if (updated.getAndSet(false)) {
@@ -55,7 +51,7 @@ class GaugeImpl extends MetricBase implements Gauge, Reportable {
         }
     }
 
-    double snapshot() {
-        return value();
+    double value() {
+        return Double.longBitsToDouble(curr.get());
     }
 }

--- a/core/src/main/java/com/uber/m3/tally/GaugeSnapshotImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/GaugeSnapshotImpl.java
@@ -28,9 +28,9 @@ import java.util.Map;
  * Default implementation of a {@link GaugeSnapshot}.
  */
 class GaugeSnapshotImpl implements GaugeSnapshot {
-    private String name;
-    private ImmutableMap<String, String> tags;
-    private double value;
+    private final String name;
+    private final ImmutableMap<String, String> tags;
+    private final double value;
 
     GaugeSnapshotImpl(String name, ImmutableMap<String, String> tags, double value) {
         this.name = name;

--- a/core/src/main/java/com/uber/m3/tally/HistogramSnapshotImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/HistogramSnapshotImpl.java
@@ -24,26 +24,20 @@ import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
 
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Default implementation of a {@link HistogramSnapshot}.
  */
 class HistogramSnapshotImpl implements HistogramSnapshot {
-    private String name;
-    private ImmutableMap<String, String> tags;
-    private Map<Double, Long> values;
-    private Map<Duration, Long> durations;
+    private final String name;
+    private final ImmutableMap<String, String> tags;
+    private final Map<Double, Long> values = new ConcurrentHashMap<>();
+    private final Map<Duration, Long> durations = new ConcurrentHashMap<>();
 
-    HistogramSnapshotImpl(
-        String name,
-        ImmutableMap<String, String> tags,
-        Map<Double, Long> values,
-        Map<Duration, Long> durations
-    ) {
+    HistogramSnapshotImpl(String name, ImmutableMap<String, String> tags) {
         this.name = name;
         this.tags = tags;
-        this.values = values;
-        this.durations = durations;
     }
 
     @Override
@@ -58,11 +52,25 @@ class HistogramSnapshotImpl implements HistogramSnapshot {
 
     @Override
     public Map<Double, Long> values() {
-        return values;
+        return new ImmutableMap<>(values);
     }
 
     @Override
     public Map<Duration, Long> durations() {
-        return durations;
+        return new ImmutableMap<>(durations);
+    }
+
+    /**
+     * Appends a new duration to the current snapshot. We kept the access modifier as default to avoid any external access.
+     */
+    void addDuration(Duration upperBound, long samples) {
+        durations.put(upperBound, samples);
+    }
+
+    /**
+     * Appends a new value to the current snapshot. We kept the access modifier as default to avoid any external access.
+     */
+    void addValue(double upperBound, long samples) {
+        values.put(upperBound, samples);
     }
 }

--- a/core/src/main/java/com/uber/m3/tally/MetricBase.java
+++ b/core/src/main/java/com/uber/m3/tally/MetricBase.java
@@ -34,5 +34,4 @@ abstract class MetricBase {
     final String getQualifiedName() {
         return fullyQualifiedName;
     }
-
 }

--- a/core/src/main/java/com/uber/m3/tally/MonotonicClock.java
+++ b/core/src/main/java/com/uber/m3/tally/MonotonicClock.java
@@ -1,0 +1,124 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.uber.m3.util.Duration;
+
+/**
+ * An interface for a monotonic clock. This is specially useful when manipulating time in tests.
+ *
+ * <p>This interface is used in time dependent sensors rather than {@link java.time.Clock} because
+ * we are only interested in measuring elapsed time and don't want to incur additional complexity
+ * due to the nature of wall-clocks time (e.g., zones, offsets, etc.).
+ */
+public interface MonotonicClock {
+    /**
+     * Returns the current value of a monotonically increasing clock measured in nanoseconds This
+     * method can only be used to measure elapsed time and is not related to any other notion of
+     * system or wall-clock time. The value returned represents nanoseconds since some fixed but
+     * arbitrary origin time (perhaps in the future, so values may be negative). The same origin is
+     * used by all invocations of this method in an instance of a Java virtual machine; other virtual
+     * machine instances are likely to use a different origin.
+     */
+    long nowNanos();
+
+    /**
+     * Returns a fake monotonic clock that can be manipulated for testing purposes.
+     */
+    static MonotonicClock.FakeClock fake() {
+        return FakeClock.create();
+    }
+
+    /**
+     * Returns a monotonic clock based on {@link System#nanoTime()}.
+     */
+    static MonotonicClock system() {
+        return new SystemClock();
+    }
+
+    /**
+     * A fake monotonic clock that can be manipulated for testing purposes.
+     */
+    class FakeClock implements MonotonicClock {
+        private final AtomicLong nowNanos = new AtomicLong(0);
+        private volatile long autoAdvanceNanos = 0;
+
+        // Private constructor to prevent instantiation. Use factory methods instead.
+        private FakeClock() {
+        }
+
+        /**
+         * Creates a new instance of {@link FakeClock}.
+         */
+        static FakeClock create() {
+            return new FakeClock();
+        }
+
+        /**
+         * Adds nanoseconds to the current measure of time.
+         */
+        public void addNanos(long nanos) {
+            this.nowNanos.addAndGet(nanos);
+        }
+
+        /**
+         * Adds the specified duration to the current measure of time.
+         */
+        public void addDuration(Duration duration) {
+            addNanos(TimeUnit.MILLISECONDS.toNanos(duration.toMillis()));
+        }
+
+        /**
+         * Advances the clock by the given nanoseconds every time {@link #nowNanos()} is called.
+         */
+        public void autoAdvanceNanos(long nanos) {
+            this.autoAdvanceNanos = nanos;
+        }
+
+        /**
+         * Advances the clock by the given duration every time {@link #nowNanos()} is called.
+         */
+        public void autoAdvanceDuration(Duration duration) {
+            autoAdvanceNanos(TimeUnit.MILLISECONDS.toNanos(duration.toMillis()));
+        }
+
+        @Override
+        public long nowNanos() {
+            return nowNanos.updateAndGet(operand -> operand + autoAdvanceNanos);
+        }
+    }
+
+    /**
+     * A monotonic clock implementation that uses {@link System#nanoTime()}
+     */
+    class SystemClock implements MonotonicClock {
+        private SystemClock() {
+        }
+
+        @Override
+        public long nowNanos() {
+            return System.nanoTime();
+        }
+    }
+}

--- a/core/src/main/java/com/uber/m3/tally/Reportable.java
+++ b/core/src/main/java/com/uber/m3/tally/Reportable.java
@@ -28,5 +28,4 @@ import com.uber.m3.util.ImmutableMap;
 interface Reportable {
 
     void report(ImmutableMap<String, String> tags, StatsReporter reporter);
-
 }

--- a/core/src/main/java/com/uber/m3/tally/ScopeBuilder.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeBuilder.java
@@ -55,6 +55,7 @@ public class ScopeBuilder {
     protected String separator = DEFAULT_SEPARATOR;
     protected ImmutableMap<String, String> tags;
     protected Buckets defaultBuckets = DEFAULT_SCOPE_BUCKETS;
+    protected MonotonicClock clock = MonotonicClock.system();
 
     private ScheduledExecutorService scheduler;
     private ScopeImpl.Registry registry;
@@ -125,6 +126,16 @@ public class ScopeBuilder {
      */
     public ScopeBuilder defaultBuckets(Buckets defaultBuckets) {
         this.defaultBuckets = defaultBuckets;
+        return this;
+    }
+
+    /**
+     * Updates the monotonic clock that should be used when measuring elapsed time.
+     * @param clock value to update to
+     * @return Builder with new param updated
+     */
+    public ScopeBuilder clock(MonotonicClock clock) {
+        this.clock = clock;
         return this;
     }
 

--- a/core/src/main/java/com/uber/m3/tally/ScopeBuilder.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeBuilder.java
@@ -68,7 +68,7 @@ public class ScopeBuilder {
     }
 
     /**
-     * Update the reporter
+     * Updates the reporter.
      * @param reporter value to update to
      * @return Builder with new param updated
      */
@@ -78,7 +78,7 @@ public class ScopeBuilder {
     }
 
     /**
-     * Update the prefix
+     * Updates the prefix.
      * @param prefix value to update to
      * @return Builder with new param updated
      */
@@ -88,7 +88,7 @@ public class ScopeBuilder {
     }
 
     /**
-     * Update the separator
+     * Updates the separator.
      * @param separator value to update to
      * @return Builder with new param updated
      */
@@ -98,7 +98,7 @@ public class ScopeBuilder {
     }
 
     /**
-     * Update the tags, cloning the tags map to an ImmutableMap
+     * Updates the tags, cloning the tags map to an ImmutableMap.
      * @param tags value to update to
      * @return Builder with new param updated
      */
@@ -109,7 +109,7 @@ public class ScopeBuilder {
     }
 
     /**
-     * Update the tags. Since this function takes an ImmutableMap, we don't need to clone it
+     * Updates the tags. Since this function takes an ImmutableMap, we don't need to clone it.
      * @param tags value to update to
      * @return Builder with new param updated
      */
@@ -120,7 +120,7 @@ public class ScopeBuilder {
     }
 
     /**
-     * Update the defaultBuckets
+     * Updates the defaultBuckets.
      * @param defaultBuckets value to update to
      * @return Builder with new param updated
      */
@@ -146,7 +146,7 @@ public class ScopeBuilder {
     }
 
     /**
-     * Creates a root scope and starts reporting with the specified interval
+     * Creates a root scope and starts reporting with the specified interval.
      * @param interval duration between each report
      * @return the root scope created
      */
@@ -155,7 +155,7 @@ public class ScopeBuilder {
     }
 
     /**
-     * Creates a root scope and starts reporting with the specified interval
+     * Creates a root scope and starts reporting with the specified interval.
      * @param interval duration between each report
      * @param uncaughtExceptionHandler an  {@link java.lang.Thread.UncaughtExceptionHandler} that's
      *                                 called when there's an uncaught exception in the report loop

--- a/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
@@ -23,7 +23,6 @@ package com.uber.m3.tally;
 import com.uber.m3.util.ImmutableMap;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -97,8 +96,7 @@ class ScopeImpl implements Scope, TestScope {
                 this,
                 fullyQualifiedName(name),
                 tags,
-                Optional.ofNullable(buckets)
-                    .orElse(defaultBuckets)
+                buckets != null ? buckets : defaultBuckets
             )
         );
     }
@@ -160,7 +158,7 @@ class ScopeImpl implements Scope, TestScope {
     }
 
     String fullyQualifiedName(String name) {
-        if (prefix == null || prefix.length() == 0) {
+        if (prefix == null || prefix.isEmpty()) {
             return name;
         }
 
@@ -168,88 +166,21 @@ class ScopeImpl implements Scope, TestScope {
     }
 
     /**
-     * Snapshot returns a copy of all values since the last report execution
+     * Snapshot returns a copy of all values since the last report execution.
      * This is an expensive operation and should only be used for testing purposes.
      *
      * @return a {@link Snapshot} of this {@link Scope}
      */
     @Override
     public Snapshot snapshot() {
-        Snapshot snap = new SnapshotImpl();
-
-        ArrayList<ScopeImpl> scopes = new ArrayList<>();
-        scopes.add(this);
-        scopes.addAll(registry.subscopes.values());
-
-        for (ScopeImpl subscope : scopes) {
-            ImmutableMap<String, String> tags = new ImmutableMap.Builder<String, String>()
-                .putAll(this.tags)
-                .putAll(subscope.tags)
-                .build();
-
-            for (Map.Entry<String, CounterImpl> counter : subscope.counters.entrySet()) {
-                String name = subscope.fullyQualifiedName(counter.getKey());
-
-                ScopeKey scopeKey = keyForPrefixedStringMap(name, tags);
-
-                snap.counters().put(
-                    scopeKey,
-                    new CounterSnapshotImpl(
-                        name,
-                        tags,
-                        counter.getValue().snapshot()
-                    )
-                );
-            }
-
-            for (Map.Entry<String, GaugeImpl> gauge : subscope.gauges.entrySet()) {
-                String name = subscope.fullyQualifiedName(gauge.getKey());
-
-                ScopeKey scopeKey = keyForPrefixedStringMap(name, tags);
-
-                snap.gauges().put(
-                    scopeKey,
-                    new GaugeSnapshotImpl(
-                        name,
-                        tags,
-                        gauge.getValue().snapshot()
-                    )
-                );
-            }
-
-            for (Map.Entry<String, TimerImpl> timer : subscope.timers.entrySet()) {
-                String name = subscope.fullyQualifiedName(timer.getKey());
-
-                ScopeKey scopeKey = keyForPrefixedStringMap(name, tags);
-
-                snap.timers().put(
-                    scopeKey,
-                    new TimerSnapshotImpl(
-                        name,
-                        tags,
-                        timer.getValue().snapshot()
-                    )
-                );
-            }
-
-            for (Map.Entry<String, HistogramImpl> histogram : subscope.histograms.entrySet()) {
-                String name = subscope.fullyQualifiedName(histogram.getKey());
-
-                ScopeKey scopeKey = keyForPrefixedStringMap(name, tags);
-
-                snap.histograms().put(
-                    scopeKey,
-                    new HistogramSnapshotImpl(
-                        name,
-                        tags,
-                        histogram.getValue().snapshotValues(),
-                        histogram.getValue().snapshotDurations()
-                    )
-                );
-            }
+        if (!(reporter instanceof SnapshotBasedStatsReporter)) {
+            throw new IllegalStateException("Snapshots can only be computed when using a SnapshotBasedStatsReporter");
         }
-
-        return snap;
+        // We will create snapshots leveraging the reporting mechanism.
+        // NOTE: Timers report directly to the reporter, so they are not handled by the report methods here.
+        report(reporter);
+        reportLoopIteration();
+        return ((SnapshotBasedStatsReporter) reporter).getFlushedSnapshot();
     }
 
     // Helper function used to create subscopes
@@ -331,7 +262,7 @@ class ScopeImpl implements Scope, TestScope {
     }
 
     static class Registry {
-        Map<ScopeKey, ScopeImpl> subscopes = new ConcurrentHashMap<>();
+        final Map<ScopeKey, ScopeImpl> subscopes = new ConcurrentHashMap<>();
     }
 
 }

--- a/core/src/main/java/com/uber/m3/tally/SnapshotBasedStatsReporter.java
+++ b/core/src/main/java/com/uber/m3/tally/SnapshotBasedStatsReporter.java
@@ -1,0 +1,134 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally;
+
+import static com.uber.m3.tally.ScopeImpl.keyForPrefixedStringMap;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.uber.m3.util.Duration;
+import com.uber.m3.util.ImmutableMap;
+
+/**
+ * A stats reporter implementation enabling snapshot recording.
+ */
+public class SnapshotBasedStatsReporter implements StatsReporter {
+    private final AtomicReference<Snapshot> currentSnapshot = new AtomicReference<>(new SnapshotImpl());
+
+    // Not synchronized as it's a read-only snapshot.
+    private volatile Snapshot flushedSnapshot = new SnapshotImpl();
+
+    /**
+     * Returns the last flushed snapshot.
+     */
+    Snapshot getFlushedSnapshot() {
+        return flushedSnapshot;
+    }
+
+    @Override
+    public Capabilities capabilities() {
+        return CapableOf.NONE;
+    }
+
+    @Override
+    public void flush() {
+        currentSnapshot.updateAndGet(snapshot -> {
+            flushedSnapshot = snapshot;
+            return new SnapshotImpl();
+        });
+    }
+
+    @Override
+    public void close() {
+        flush();
+    }
+
+    @Override
+    public void reportCounter(String name, Map<String, String> tags, long value) {
+        ImmutableMap<String, String> tagsKey = toImmutable(tags);
+        ScopeKey scopeKey = keyForPrefixedStringMap(name, tagsKey);
+        currentSnapshot.get().counters().compute(scopeKey, (k, v) -> new CounterSnapshotImpl(name, tagsKey, value));
+    }
+
+    @Override
+    public void reportGauge(String name, Map<String, String> tags, double value) {
+        ImmutableMap<String, String> tagsKey = toImmutable(tags);
+        ScopeKey scopeKey = keyForPrefixedStringMap(name, tagsKey);
+        currentSnapshot.get().gauges().compute(scopeKey, (k, v) -> new GaugeSnapshotImpl(name, tagsKey, value));
+    }
+
+    @Override
+    public void reportTimer(String name, Map<String, String> tags, Duration interval) {
+        ImmutableMap<String, String> tagsKey = toImmutable(tags);
+        ScopeKey scopeKey = keyForPrefixedStringMap(name, tagsKey);
+        currentSnapshot.get().timers().computeIfAbsent(scopeKey, k -> new TimerSnapshotImpl(name, tagsKey));
+        currentSnapshot.get().timers().computeIfPresent(scopeKey, (k, snapshot) -> {
+            ((TimerSnapshotImpl) snapshot).addDuration(interval);
+            return snapshot;
+        });
+    }
+
+    @Override
+    public void reportHistogramValueSamples(String name, Map<String, String> tags, Buckets buckets, double bucketLowerBound, double bucketUpperBound, long samples) {
+        ImmutableMap<String, String> tagsKey = toImmutable(tags);
+        ScopeKey scopeKey = keyForPrefixedStringMap(name, tagsKey);
+        ensureHistogramBucketsFor(name, tagsKey, buckets);
+        currentSnapshot.get().histograms().computeIfPresent(scopeKey, (k, snapshot) -> {
+            ((HistogramSnapshotImpl) snapshot).addValue(bucketUpperBound, samples);
+            return snapshot;
+        });
+    }
+
+    @Override
+    public void reportHistogramDurationSamples(String name, Map<String, String> tags, Buckets buckets, Duration bucketLowerBound, Duration bucketUpperBound, long samples) {
+        ImmutableMap<String, String> tagsKey = toImmutable(tags);
+        ScopeKey scopeKey = keyForPrefixedStringMap(name, toImmutable(tags));
+        ensureHistogramBucketsFor(name, tagsKey, buckets);
+        currentSnapshot.get().histograms().computeIfPresent(scopeKey, (k, snapshot) -> {
+            ((HistogramSnapshotImpl) snapshot).addDuration(bucketUpperBound, samples);
+            return snapshot;
+        });
+    }
+
+    private void ensureHistogramBucketsFor(String name, ImmutableMap<String, String> tags, Buckets buckets) {
+        ScopeKey scopeKey = keyForPrefixedStringMap(name, tags);
+        currentSnapshot.get().histograms().computeIfAbsent(scopeKey, k -> {
+            HistogramSnapshotImpl snapshot = new HistogramSnapshotImpl(name, tags);
+            for (int i = 0; i <= buckets.asValues().length; ++i) {
+                if (buckets instanceof DurationBuckets) {
+                    snapshot.addDuration(buckets.getDurationUpperBoundFor(i), 0);
+                }
+                if (buckets instanceof ValueBuckets) {
+                    snapshot.addValue(buckets.getValueUpperBoundFor(i), 0);
+                }
+            }
+            return snapshot;
+        });
+    }
+
+    private static ImmutableMap<String, String> toImmutable(Map<String, String> tags) {
+        if (tags == null) {
+            return ImmutableMap.EMPTY;
+        }
+        return new ImmutableMap<>(tags);
+    }
+}

--- a/core/src/main/java/com/uber/m3/tally/SnapshotImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/SnapshotImpl.java
@@ -27,10 +27,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * Default implementation of a {@link Snapshot}.
  */
 class SnapshotImpl implements Snapshot {
-    Map<ScopeKey, CounterSnapshot> counters = new ConcurrentHashMap<>();
-    Map<ScopeKey, GaugeSnapshot> gauges = new ConcurrentHashMap<>();
-    Map<ScopeKey, TimerSnapshot> timers = new ConcurrentHashMap<>();
-    Map<ScopeKey, HistogramSnapshot> histograms = new ConcurrentHashMap<>();
+    private final Map<ScopeKey, CounterSnapshot> counters = new ConcurrentHashMap<>();
+    private final Map<ScopeKey, GaugeSnapshot> gauges = new ConcurrentHashMap<>();
+    private final Map<ScopeKey, TimerSnapshot> timers = new ConcurrentHashMap<>();
+    private final Map<ScopeKey, HistogramSnapshot> histograms = new ConcurrentHashMap<>();
 
     @Override
     public Map<ScopeKey, CounterSnapshot> counters() {

--- a/core/src/main/java/com/uber/m3/tally/Stopwatch.java
+++ b/core/src/main/java/com/uber/m3/tally/Stopwatch.java
@@ -27,8 +27,8 @@ package com.uber.m3.tally;
  * of the stopwatch are comparable with one another.
  */
 public class Stopwatch {
-    private long startNanos;
-    private StopwatchRecorder recorder;
+    private final long startNanos;
+    private final StopwatchRecorder recorder;
 
     /**
      * Creates a stopwatch.

--- a/core/src/main/java/com/uber/m3/tally/TestScope.java
+++ b/core/src/main/java/com/uber/m3/tally/TestScope.java
@@ -34,7 +34,7 @@ public interface TestScope extends Scope {
      */
     static TestScope create() {
         return new RootScopeBuilder()
-            .reporter(new NullStatsReporter())
+            .reporter(new SnapshotBasedStatsReporter())
             .build();
     }
 
@@ -45,7 +45,7 @@ public interface TestScope extends Scope {
     static TestScope create(MonotonicClock clock) {
         return new RootScopeBuilder()
             .clock(clock)
-            .reporter(new NullStatsReporter())
+            .reporter(new SnapshotBasedStatsReporter())
             .build();
     }
 
@@ -57,7 +57,7 @@ public interface TestScope extends Scope {
         return new RootScopeBuilder()
             .prefix(prefix)
             .tags(tags)
-            .reporter(new NullStatsReporter())
+            .reporter(new SnapshotBasedStatsReporter())
             .build();
     }
 
@@ -70,7 +70,7 @@ public interface TestScope extends Scope {
             .clock(clock)
             .prefix(prefix)
             .tags(tags)
-            .reporter(new NullStatsReporter())
+            .reporter(new SnapshotBasedStatsReporter())
             .build();
     }
 

--- a/core/src/main/java/com/uber/m3/tally/TestScope.java
+++ b/core/src/main/java/com/uber/m3/tally/TestScope.java
@@ -34,8 +34,19 @@ public interface TestScope extends Scope {
      */
     static TestScope create() {
         return new RootScopeBuilder()
-                .reporter(new NullStatsReporter())
-                .build();
+            .reporter(new NullStatsReporter())
+            .build();
+    }
+
+    /**
+     * Creates a new TestScope that adds the ability to manipulate time and take snapshots of
+     * metrics emitted to it.
+     */
+    static TestScope create(MonotonicClock clock) {
+        return new RootScopeBuilder()
+            .clock(clock)
+            .reporter(new NullStatsReporter())
+            .build();
     }
 
     /**
@@ -44,14 +55,27 @@ public interface TestScope extends Scope {
      */
     static TestScope create(String prefix, Map<String, String> tags) {
         return new RootScopeBuilder()
-                .prefix(prefix)
-                .tags(tags)
-                .reporter(new NullStatsReporter())
-                .build();
+            .prefix(prefix)
+            .tags(tags)
+            .reporter(new NullStatsReporter())
+            .build();
     }
 
     /**
-     * Snapshot returns a copy of all values since the last report execution
+     * Creates a new TestScope with given prefix/tags that adds the ability to manipulate time and
+     * take snapshots of metrics emitted to it.
+     */
+    static TestScope create(String prefix, Map<String, String> tags, MonotonicClock clock) {
+        return new RootScopeBuilder()
+            .clock(clock)
+            .prefix(prefix)
+            .tags(tags)
+            .reporter(new NullStatsReporter())
+            .build();
+    }
+
+    /**
+     * Snapshot returns a copy of all values since the last report execution.
      * This is an expensive operation and should only be used for testing purposes.
      */
     Snapshot snapshot();

--- a/core/src/main/java/com/uber/m3/tally/TimerImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/TimerImpl.java
@@ -34,12 +34,14 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Default implementation of a {@link Timer}.
  */
 class TimerImpl implements Timer, StopwatchRecorder {
-    private String name;
-    private ImmutableMap<String, String> tags;
-    private StatsReporter reporter;
-    private Values unreported = new Values();
+    private final MonotonicClock clock;
+    private final String name;
+    private final ImmutableMap<String, String> tags;
+    private final StatsReporter reporter;
+    private final Values unreported = new Values();
 
-    TimerImpl(String name, ImmutableMap<String, String> tags, StatsReporter reporter) {
+    TimerImpl(MonotonicClock clock, String name, ImmutableMap<String, String> tags, StatsReporter reporter) {
+        this.clock = clock;
         this.name = name;
         this.tags = tags;
 
@@ -57,7 +59,7 @@ class TimerImpl implements Timer, StopwatchRecorder {
 
     @Override
     public Stopwatch start() {
-        return new Stopwatch(System.nanoTime(), this);
+        return new Stopwatch(clock.nowNanos(), this);
     }
 
     /**
@@ -66,7 +68,7 @@ class TimerImpl implements Timer, StopwatchRecorder {
      */
     @Override
     public void recordStopwatch(long stopwatchStart) {
-        record(Duration.between(stopwatchStart, System.nanoTime()));
+        record(Duration.between(stopwatchStart, clock.nowNanos()));
     }
 
     Duration[] snapshot() {

--- a/core/src/main/java/com/uber/m3/tally/TimerSnapshotImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/TimerSnapshotImpl.java
@@ -23,20 +23,21 @@ package com.uber.m3.tally;
 import com.uber.m3.util.Duration;
 import com.uber.m3.util.ImmutableMap;
 
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Default implementation of a {@link TimerSnapshot}.
  */
 class TimerSnapshotImpl implements TimerSnapshot {
-    private String name;
-    private ImmutableMap<String, String> tags;
-    private Duration[] values;
+    private final String name;
+    private final ImmutableMap<String, String> tags;
+    private final List<Duration> values = new CopyOnWriteArrayList<>();
 
-    TimerSnapshotImpl(String name, ImmutableMap<String, String> tags, Duration[] values) {
+    TimerSnapshotImpl(String name, ImmutableMap<String, String> tags) {
         this.name = name;
         this.tags = tags;
-        this.values = values;
     }
 
     @Override
@@ -51,6 +52,13 @@ class TimerSnapshotImpl implements TimerSnapshot {
 
     @Override
     public Duration[] values() {
-        return values;
+        return values.toArray(new Duration[0]);
+    }
+
+    /**
+     * Appends a new duration to the current snapshot. We kept the access modifier as default to avoid any external access.
+     */
+    void addDuration(Duration duration) {
+        values.add(duration);
     }
 }

--- a/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
+++ b/core/src/main/java/com/uber/m3/tally/ValueBuckets.java
@@ -124,10 +124,10 @@ public class ValueBuckets extends AbstractBuckets<Double> {
 
     /**
      * Helper function to create {@link ValueBuckets} of exponential spacing.
-     * @param start      the starting bucket's value}
+     * @param start      the starting bucket's value
      * @param factor     the factor between each bucket
      * @param numBuckets the number of buckets to create
-     * @return {@link ValueBuckets} of the specified paramters
+     * @return {@link ValueBuckets} of the specified parameters
      */
     public static ValueBuckets exponential(double start, double factor, int numBuckets) {
         if (numBuckets <= 0) {
@@ -155,7 +155,7 @@ public class ValueBuckets extends AbstractBuckets<Double> {
      * Helper function to create {@link ValueBuckets} with custom buckets.
      *
      * @param sortedBucketUpperValues sorted (ascending order) values of bucket's upper bound
-     * @return {@link ValueBuckets} of the specified paramters
+     * @return {@link ValueBuckets} of the specified parameters
      */
     public static ValueBuckets custom(double... sortedBucketUpperValues) {
         if (sortedBucketUpperValues == null || sortedBucketUpperValues.length == 0) {

--- a/core/src/test/java/com/uber/m3/tally/BucketPairImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/BucketPairImplTest.java
@@ -23,10 +23,7 @@ package com.uber.m3.tally;
 import com.uber.m3.util.Duration;
 import org.junit.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class BucketPairImplTest {
     @Test
@@ -97,11 +94,11 @@ public class BucketPairImplTest {
         BucketPair bucketPair = BucketPairImpl.bucketPairs(null)[0];
         BucketPair sameBucketPair = BucketPairImpl.bucketPairs(null)[0];
 
-        assertTrue(bucketPair.equals(sameBucketPair));
-        assertTrue(bucketPair.equals(bucketPair));
+        assertEquals(bucketPair, sameBucketPair);
+        assertEquals(bucketPair, bucketPair);
         assertEquals(bucketPair.hashCode(), sameBucketPair.hashCode());
 
-        assertFalse(bucketPair.equals(null));
-        assertFalse(bucketPair.equals(9));
+        assertNotEquals(null, bucketPair);
+        assertNotEquals(9, bucketPair);
     }
 }

--- a/core/src/test/java/com/uber/m3/tally/CapableOfTest.java
+++ b/core/src/test/java/com/uber/m3/tally/CapableOfTest.java
@@ -20,15 +20,13 @@
 
 package com.uber.m3.tally;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class CapableOfTest {
     @Test
-    public void capabilities() throws Exception {
+    public void capabilities() {
         Capabilities capabilities = new CapableOf(false, true);
 
         assertFalse(capabilities.reporting());
@@ -45,16 +43,16 @@ public class CapableOfTest {
     }
 
     @Test
-    public void equalsHashCode() throws Exception {
-        assertFalse(CapableOf.NONE.equals(null));
-        assertFalse(CapableOf.NONE.equals(9));
+    public void equalsHashCode() {
+        assertNotEquals(null, CapableOf.NONE);
+        assertNotEquals(9, CapableOf.NONE);
 
-        assertFalse(CapableOf.NONE.equals(CapableOf.REPORTING));
-        assertFalse(new CapableOf(true, false).equals(new CapableOf(false, true)));
+        assertNotEquals(CapableOf.NONE, CapableOf.REPORTING);
+        assertNotEquals(new CapableOf(true, false), new CapableOf(false, true));
 
-        assertTrue(CapableOf.REPORTING.equals(CapableOf.REPORTING));
-        assertTrue(CapableOf.REPORTING.equals(new CapableOf(true, false)));
+        assertEquals(CapableOf.REPORTING, CapableOf.REPORTING);
+        assertEquals(CapableOf.REPORTING, new CapableOf(true, false));
         assertEquals(CapableOf.REPORTING.hashCode(), new CapableOf(true, false).hashCode());
-        assertTrue(new CapableOf(false, false).equals(new CapableOf(false, false)));
+        assertEquals(new CapableOf(false, false), new CapableOf(false, false));
     }
 }

--- a/core/src/test/java/com/uber/m3/tally/MonotonicClockFakeClockTest.java
+++ b/core/src/test/java/com/uber/m3/tally/MonotonicClockFakeClockTest.java
@@ -1,0 +1,75 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.m3.tally;
+
+import com.uber.m3.util.Duration;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class MonotonicClockFakeClockTest {
+
+    @Test
+    public void testAddNanos() {
+        MonotonicClock.FakeClock clock = MonotonicClock.fake();
+
+        assertEquals(0, clock.nowNanos());
+        clock.addNanos(100);
+        assertEquals(100, clock.nowNanos());
+    }
+
+    @Test
+    public void testAddDuration() {
+        MonotonicClock.FakeClock clock = MonotonicClock.fake();
+
+        assertEquals(0, clock.nowNanos());
+        clock.addDuration(Duration.ofMillis(10));
+        assertEquals(10_000_000, clock.nowNanos());
+    }
+
+    @Test
+    public void testAutoAdvanceNanos() {
+        MonotonicClock.FakeClock clock = MonotonicClock.fake();
+
+        clock.autoAdvanceNanos(10);
+        assertEquals(10, clock.nowNanos());
+        assertEquals(20, clock.nowNanos());
+        assertEquals(30, clock.nowNanos());
+
+        clock.autoAdvanceNanos(20);
+        assertEquals(50, clock.nowNanos());
+        assertEquals(70, clock.nowNanos());
+    }
+
+    @Test
+    public void testAutoAdvanceDuration() {
+        MonotonicClock.FakeClock clock = MonotonicClock.fake();
+
+        clock.autoAdvanceDuration(Duration.ofMillis(10));
+        assertEquals(10_000_000, clock.nowNanos());
+        assertEquals(20_000_000, clock.nowNanos());
+        assertEquals(30_000_000, clock.nowNanos());
+
+        clock.autoAdvanceDuration(Duration.ofMillis(20));
+        assertEquals(50_000_000, clock.nowNanos());
+        assertEquals(70_000_000, clock.nowNanos());
+    }
+}

--- a/core/src/test/java/com/uber/m3/tally/NoopScopeTest.java
+++ b/core/src/test/java/com/uber/m3/tally/NoopScopeTest.java
@@ -20,12 +20,13 @@
 
 package com.uber.m3.tally;
 
+import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
 
 public class NoopScopeTest {
 
@@ -34,15 +35,15 @@ public class NoopScopeTest {
         NoopScope noopScope = new NoopScope();
         Counter noopCounter1 = noopScope.counter("test1");
         Counter noopCounter2 = noopScope.counter("test2");
-        Assert.assertThat(
-                "same noop counter returned",
-                noopCounter1 == noopCounter2,
-                CoreMatchers.equalTo(true)
+        assertThat(
+            "same noop counter returned",
+            noopCounter1 == noopCounter2,
+            equalTo(true)
         );
-        Assert.assertThat(
-                "noop counter",
-                noopCounter1 == NoopScope.NOOP_COUNTER,
-                CoreMatchers.equalTo(true)
+        assertThat(
+            "noop counter",
+            noopCounter1 == NoopScope.NOOP_COUNTER,
+            equalTo(true)
         );
     }
 
@@ -51,15 +52,15 @@ public class NoopScopeTest {
         NoopScope noopScope = new NoopScope();
         Gauge noopGauge1 = noopScope.gauge("test1");
         Gauge noopGauge2 = noopScope.gauge("test2");
-        Assert.assertThat(
-                "same noop gauge returned",
-                noopGauge1 == noopGauge2,
-                CoreMatchers.equalTo(true)
+        assertThat(
+            "same noop gauge returned",
+            noopGauge1 == noopGauge2,
+            equalTo(true)
         );
-        Assert.assertThat(
-                "noop gauge",
-                noopGauge1 == NoopScope.NOOP_GAUGE,
-                CoreMatchers.equalTo(true)
+        assertThat(
+            "noop gauge",
+            noopGauge1 == NoopScope.NOOP_GAUGE,
+            equalTo(true)
         );
     }
 
@@ -68,20 +69,20 @@ public class NoopScopeTest {
         NoopScope noopScope = new NoopScope();
         Timer noopTimer1 = noopScope.timer("test1");
         Timer noopTimer2 = noopScope.timer("test2");
-        Assert.assertThat(
-                "same noop timer returned",
-                noopTimer1 == noopTimer2,
-                CoreMatchers.equalTo(true)
+        assertThat(
+            "same noop timer returned",
+            noopTimer1 == noopTimer2,
+            equalTo(true)
         );
-        Assert.assertThat(
-                "noop timer",
-                noopTimer1 == NoopScope.NOOP_TIMER,
-                CoreMatchers.equalTo(true)
+        assertThat(
+            "noop timer",
+            noopTimer1 == NoopScope.NOOP_TIMER,
+            equalTo(true)
         );
-        Assert.assertThat(
-                "noop stopwatch",
-                noopTimer1.start() == NoopScope.NOOP_STOPWATCH,
-                CoreMatchers.equalTo(true)
+        assertThat(
+            "noop stopwatch",
+            noopTimer1.start() == NoopScope.NOOP_STOPWATCH,
+            equalTo(true)
         );
     }
 
@@ -91,15 +92,15 @@ public class NoopScopeTest {
         Histogram noopHistogram1 = noopScope.histogram("test1", ValueBuckets.custom(1, 2, 3));
         Histogram noopHistogram2 = noopScope.histogram("test2", ValueBuckets.custom(4, 5, 6));
 
-        Assert.assertThat(
-                "same noop histogram returned",
-                noopHistogram1 == noopHistogram2,
-                CoreMatchers.equalTo(true)
+        assertThat(
+            "same noop histogram returned",
+            noopHistogram1 == noopHistogram2,
+            equalTo(true)
         );
-        Assert.assertThat(
-                "noop histogram",
-                noopHistogram1 == NoopScope.NOOP_HISTOGRAM,
-                CoreMatchers.equalTo(true)
+        assertThat(
+            "noop histogram",
+            noopHistogram1 == NoopScope.NOOP_HISTOGRAM,
+            equalTo(true)
         );
     }
 
@@ -108,15 +109,15 @@ public class NoopScopeTest {
         NoopScope noopScope = new NoopScope();
         Capabilities noopCapabilities1 = noopScope.capabilities();
         Capabilities noopCapabilities2 = noopScope.capabilities();
-        Assert.assertThat(
-                "same noop capabilities returned",
-                noopCapabilities1 == noopCapabilities2,
-                CoreMatchers.equalTo(true)
+        assertThat(
+            "same noop capabilities returned",
+            noopCapabilities1 == noopCapabilities2,
+            equalTo(true)
         );
-        Assert.assertThat(
-                "noop capabilities",
-                noopCapabilities1 == NoopScope.NOOP_CAPABILITIES,
-                CoreMatchers.equalTo(true)
+        assertThat(
+            "noop capabilities",
+            noopCapabilities1 == NoopScope.NOOP_CAPABILITIES,
+            equalTo(true)
         );
     }
 
@@ -125,13 +126,13 @@ public class NoopScopeTest {
         NoopScope noopScope = new NoopScope();
         Scope noopScope1 = noopScope.subScope("test1");
         Scope noopScope2 = noopScope.subScope("test2");
-        Assert.assertThat("same noop scope returned",
-                noopScope1 == noopScope2,
-                CoreMatchers.equalTo(true)
+        assertThat("same noop scope returned",
+            noopScope1 == noopScope2,
+            equalTo(true)
         );
-        Assert.assertThat("noop scope returned",
-                noopScope1 == noopScope,
-                CoreMatchers.equalTo(true)
+        assertThat("noop scope returned",
+            noopScope1 == noopScope,
+            equalTo(true)
         );
     }
 
@@ -148,13 +149,13 @@ public class NoopScopeTest {
 
         Scope noopScope1 = noopScope.tagged(tagMap1);
         Scope noopScope2 = noopScope.tagged(tagMap2);
-        Assert.assertThat("same noop scope returned",
-                noopScope1 == noopScope2,
-                CoreMatchers.equalTo(true)
+        assertThat("same noop scope returned",
+            noopScope1 == noopScope2,
+            equalTo(true)
         );
-        Assert.assertThat("noop scope returned",
-                noopScope1 == noopScope,
-                CoreMatchers.equalTo(true)
+        assertThat("noop scope returned",
+            noopScope1 == noopScope,
+            equalTo(true)
         );
     }
 }

--- a/core/src/test/java/com/uber/m3/tally/TestScopeTest.java
+++ b/core/src/test/java/com/uber/m3/tally/TestScopeTest.java
@@ -20,17 +20,14 @@
 
 package com.uber.m3.tally;
 
-import com.uber.m3.util.ImmutableMap;
 import com.uber.m3.util.Duration;
+import com.uber.m3.util.ImmutableMap;
 import org.junit.Test;
 
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class TestScopeTest {
 
@@ -163,6 +160,171 @@ public class TestScopeTest {
         assertNotNull(histogramSnapshot);
         assertEquals("prefix.histogram", histogramSnapshot.name());
         assertEquals(1, histogramSnapshot.durations().get(Duration.ofMillis(30)).longValue());
+    }
+
+    @Test
+    public void testCreateWithClockAndTimer() {
+        MonotonicClock.FakeClock clock = MonotonicClock.fake();
+        TestScope testScope = TestScope.create(clock);
+
+        Stopwatch stopwatch = testScope.timer("timer").start();
+        clock.addNanos(10);
+        stopwatch.stop();
+
+        Snapshot snapshot = testScope.snapshot();
+        assertNotNull(snapshot);
+
+        Map<ScopeKey, TimerSnapshot> timers = snapshot.timers();
+        assertNotNull(timers);
+        assertEquals(1, timers.size());
+
+        TimerSnapshot timerSnapshot = timers.get(new ScopeKey("timer", ImmutableMap.EMPTY));
+
+        assertNotNull(timerSnapshot);
+        assertEquals("timer", timerSnapshot.name());
+        assertEquals(1, timerSnapshot.values().length);
+        assertEquals(Duration.ofNanos(10), timerSnapshot.values()[0]);
+    }
+
+    @Test
+    public void testCreateWithTagsAndClockAndTimer() {
+        ImmutableMap<String, String> tags = ImmutableMap.of("key", "value");
+        MonotonicClock.FakeClock clock = MonotonicClock.fake();
+        TestScope testScope = TestScope.create("prefix", tags, clock);
+        Scope tagged = testScope.tagged(ImmutableMap.of("other_key", "other_value"));
+
+        Stopwatch stopwatch = tagged.timer("timer").start();
+        clock.addNanos(10);
+        stopwatch.stop();
+
+        Snapshot snapshot = testScope.snapshot();
+        assertNotNull(snapshot);
+
+        Map<ScopeKey, TimerSnapshot> timers = snapshot.timers();
+        assertNotNull(timers);
+        assertEquals(1, timers.size());
+
+        ImmutableMap<String, String> totalTags = ImmutableMap.of("key", "value", "other_key", "other_value");
+        TimerSnapshot timerSnapshot = timers.get(new ScopeKey("prefix.timer", totalTags));
+
+        assertNotNull(timerSnapshot);
+        assertEquals("prefix.timer", timerSnapshot.name());
+        assertEquals(totalTags, timerSnapshot.tags());
+        assertEquals(1, timerSnapshot.values().length);
+        assertEquals(Duration.ofNanos(10), timerSnapshot.values()[0]);
+    }
+
+    @Test
+    public void testCounterSnapshot() {
+        TestScope testScope = TestScope.create("prefix", ImmutableMap.EMPTY);
+        testScope.tagged(ImmutableMap.of("key", "value")).counter("counter").inc(1);
+
+        Snapshot snapshot = testScope.snapshot();
+        assertNotNull(snapshot);
+
+        Map<ScopeKey, CounterSnapshot> counters = snapshot.counters();
+        assertNotNull(counters);
+        assertEquals(1, counters.size());
+
+        ImmutableMap<String, String> totalTags = ImmutableMap.of("key", "value");
+        CounterSnapshot counterSnapshot = counters.get(new ScopeKey("prefix.counter", totalTags));
+
+        assertNotNull(counterSnapshot);
+        assertEquals("prefix.counter", counterSnapshot.name());
+        assertEquals(totalTags, counterSnapshot.tags());
+        assertEquals(1, counterSnapshot.value());
+    }
+
+    @Test
+    public void testTimerSnapshot() {
+        MonotonicClock.FakeClock clock = MonotonicClock.fake();
+        TestScope testScope = TestScope.create("prefix", ImmutableMap.EMPTY, clock);
+        Scope subscope = testScope.tagged(ImmutableMap.of("key", "value"));
+
+        Timer timer = subscope.timer("timer");
+
+        // Test record directly.
+        timer.record(Duration.ofNanos(100));
+
+        // Test record via stopwatch.
+        Stopwatch stopwatch = timer.start();
+        clock.addNanos(10);
+        stopwatch.stop();
+
+        Snapshot snapshot = testScope.snapshot();
+        assertNotNull(snapshot);
+
+        Map<ScopeKey, TimerSnapshot> timers = snapshot.timers();
+        assertNotNull(timers);
+        assertEquals(1, timers.size());
+
+        ImmutableMap<String, String> totalTags = ImmutableMap.of("key", "value");
+        TimerSnapshot timerSnapshot = timers.get(new ScopeKey("prefix.timer", totalTags));
+
+        assertNotNull(timerSnapshot);
+        assertEquals("prefix.timer", timerSnapshot.name());
+        assertEquals(totalTags, timerSnapshot.tags());
+        assertArrayEquals(new Duration[]{Duration.ofNanos(100), Duration.ofNanos(10)}, timerSnapshot.values());
+    }
+
+    @Test
+    public void testHistogramSnapshot() {
+        MonotonicClock.FakeClock clock = MonotonicClock.fake();
+        Buckets buckets = DurationBuckets.linear(Duration.ZERO, Duration.ofMillis(10), 5);
+        TestScope testScope = TestScope.create("prefix", ImmutableMap.EMPTY);
+        Scope subscope = testScope.tagged(ImmutableMap.of("key", "value"));
+
+        Histogram histogram = subscope.histogram("histogram", buckets);
+        // Test record directly.
+        histogram.recordDuration(Duration.ofMillis(15));
+
+        // Test record via stopwatch.
+        Stopwatch stopwatch = histogram.start();
+        clock.addDuration(Duration.ofMillis(25));
+        stopwatch.stop();
+
+        Snapshot snapshot = testScope.snapshot();
+        assertNotNull(snapshot);
+
+        Map<ScopeKey, HistogramSnapshot> histogramSnapshots = snapshot.histograms();
+        assertNotNull(histogramSnapshots);
+        assertEquals(1, histogramSnapshots.size());
+
+        ImmutableMap<String, String> totalTags = ImmutableMap.of("key", "value");
+        HistogramSnapshot histogramSnapshot = histogramSnapshots.get(new ScopeKey("prefix.histogram", totalTags));
+
+        assertNotNull(histogramSnapshot);
+        assertEquals("prefix.histogram", histogramSnapshot.name());
+        assertEquals(totalTags, histogramSnapshot.tags());
+
+        // Total of 2 samples.
+        assertEquals(2, histogramSnapshot.durations().values().stream().mapToLong(it -> it).sum());
+        assertEquals(1, histogramSnapshot.durations().get(Duration.ofMillis(20)).longValue());
+        assertEquals(1, histogramSnapshot.durations().get(Duration.ofMillis(10)).longValue());
+    }
+
+    @Test
+    public void testGaugeSnapshot() {
+        TestScope testScope = TestScope.create("prefix", ImmutableMap.EMPTY);
+        Scope subscope = testScope.tagged(ImmutableMap.of("key", "value"));
+
+        subscope.gauge("gauge").update(20.0);
+
+        Snapshot snapshot = testScope.snapshot();
+        assertNotNull(snapshot);
+
+        Map<ScopeKey, GaugeSnapshot> gauge = snapshot.gauges();
+        assertNotNull(gauge);
+        assertEquals(1, gauge.size());
+
+        ImmutableMap<String, String> totalTags = ImmutableMap.of("key", "value");
+        GaugeSnapshot gaugeSnapshot = gauge.get(new ScopeKey("prefix.gauge", totalTags));
+
+        assertNotNull(gaugeSnapshot);
+        assertEquals("prefix.gauge", gaugeSnapshot.name());
+        assertEquals(totalTags, gaugeSnapshot.tags());
+
+        assertEquals(20.0, gaugeSnapshot.value(), 0.01);
     }
 }
 

--- a/core/src/test/java/com/uber/m3/tally/TestStatsReporter.java
+++ b/core/src/test/java/com/uber/m3/tally/TestStatsReporter.java
@@ -29,14 +29,14 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class TestStatsReporter implements StatsReporter {
-    private Queue<MetricStruct<Long>> counters = new ConcurrentLinkedQueue<>();
-    private Queue<MetricStruct<Double>> gauges = new ConcurrentLinkedQueue<>();
-    private Queue<MetricStruct<Duration>> timers = new ConcurrentLinkedQueue<>();
-    private Buckets buckets;
-    private Map<Double, Long> valueSamples = new HashMap<>();
-    private Map<Duration, Long> durationSamples = new HashMap<>();
+    private final Queue<MetricStruct<Long>> counters = new ConcurrentLinkedQueue<>();
+    private final Queue<MetricStruct<Double>> gauges = new ConcurrentLinkedQueue<>();
+    private final Queue<MetricStruct<Duration>> timers = new ConcurrentLinkedQueue<>();
+    private final Map<Double, Long> valueSamples = new HashMap<>();
+    private final Map<Duration, Long> durationSamples = new HashMap<>();
+    private final Map<Double, Long> cumulativeValueSamples = new HashMap<>();
 
-    private Map<Double, Long> cumulativeValueSamples = new HashMap<>();
+    private Buckets buckets;
 
     @Override
     public void reportCounter(String name, Map<String, String> tags, long value) {

--- a/core/src/test/java/com/uber/m3/tally/TimerImplTest.java
+++ b/core/src/test/java/com/uber/m3/tally/TimerImplTest.java
@@ -21,8 +21,10 @@
 package com.uber.m3.tally;
 
 import com.uber.m3.util.Duration;
+import com.uber.m3.util.ImmutableMap;
 import org.junit.Test;
 
+import static com.uber.m3.tally.ScopeImpl.keyForPrefixedStringMap;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -48,42 +50,64 @@ public class TimerImplTest {
     }
 
     @Test
-    public void noReporterSinkSnapshot() {
-        TimerImpl timer = new TimerImpl(clock, "no-reporter-timer", null, null);
+    public void snapshotDuration() {
+        SnapshotBasedStatsReporter snapshotReporter = new SnapshotBasedStatsReporter();
+        ScopeImpl scope =
+            new ScopeBuilder(null, new ScopeImpl.Registry())
+                .reporter(snapshotReporter)
+                .clock(clock)
+                .build();
+        Timer timer = scope.timer("timer");
 
-        StatsReporter sink = timer.new NoReporterSink();
+        timer.record(Duration.ofMillis(42));
+        Snapshot snapshot1 = scope.snapshot();
 
-        // No-ops
-        sink.flush();
-        sink.close();
+        assertArrayEquals(
+            new Duration[]{Duration.ofMillis(42)},
+            getSnapshot(snapshot1, "timer").values());
 
-        assertEquals(CapableOf.REPORTING_TAGGING, sink.capabilities());
-        sink.reportTimer("new-timer", null, Duration.ofMillis(888));
+        timer.record(Duration.ofMillis(3));
+        timer.record(Duration.ofMillis(2));
+        timer.record(Duration.ofMillis(1));
+        Snapshot snapshot2 = scope.snapshot();
 
-        assertArrayEquals(new Duration[]{Duration.ofMillis(888)}, timer.snapshot());
+        assertArrayEquals(
+            new Duration[]{Duration.ofMillis(3), Duration.ofMillis(2), Duration.ofMillis(1)},
+            getSnapshot(snapshot2, "timer").values());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void unsupportedCounter() {
-        StatsReporter sink = new TimerImpl(clock, "", null, null).new NoReporterSink();
-        sink.reportCounter(null, null, 0);
+    @Test
+    public void snapshotStopwatch() {
+        SnapshotBasedStatsReporter snapshotReporter = new SnapshotBasedStatsReporter();
+        ScopeImpl scope =
+            new ScopeBuilder(null, new ScopeImpl.Registry())
+                .reporter(snapshotReporter)
+                .clock(clock)
+                .build();
+        Timer timer = scope.timer("timer");
+
+        Stopwatch stopwatch1 = timer.start();
+        clock.addNanos(100);
+        stopwatch1.stop();
+        Snapshot snapshot1 = scope.snapshot();
+        assertArrayEquals(
+            new Duration[]{Duration.ofNanos(100)},
+            getSnapshot(snapshot1, "timer").values());
+
+        Stopwatch stopwatch2 = timer.start();
+        clock.addNanos(200);
+        stopwatch2.stop();
+        Stopwatch stopwatch3 = timer.start();
+        clock.addNanos(150);
+        stopwatch3.stop();
+        Snapshot snapshot2 = scope.snapshot();
+        assertArrayEquals(
+            new Duration[]{Duration.ofNanos(200), Duration.ofNanos(150)},
+            getSnapshot(snapshot2, "timer").values());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void unsupportedGauge() {
-        StatsReporter sink = new TimerImpl(clock, "", null, null).new NoReporterSink();
-        sink.reportGauge(null, null, 0);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void unsupportedHistogramValue() {
-        StatsReporter sink = new TimerImpl(clock, "", null, null).new NoReporterSink();
-        sink.reportHistogramValueSamples(null, null, null, 0, 0, 0);
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void unsupportedHistogramDuration() {
-        StatsReporter sink = new TimerImpl(clock, "", null, null).new NoReporterSink();
-        sink.reportHistogramDurationSamples(null, null, null, null, null, 0);
+    private static TimerSnapshot getSnapshot(Snapshot snapshot, String name) {
+        ScopeKey key = keyForPrefixedStringMap(name, ImmutableMap.EMPTY);
+        return snapshot.timers().get(key);
     }
 }

--- a/core/src/test/java/com/uber/m3/tally/ValueBucketsTest.java
+++ b/core/src/test/java/com/uber/m3/tally/ValueBucketsTest.java
@@ -20,16 +20,11 @@
 
 package com.uber.m3.tally;
 
+import com.uber.m3.util.Duration;
 import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
-import com.uber.m3.util.Duration;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 
 public class ValueBucketsTest {
     @Test
@@ -151,10 +146,10 @@ public class ValueBucketsTest {
         ValueBuckets buckets = ValueBuckets.linear(0, 10, 3);
         ValueBuckets sameBuckets = ValueBuckets.linear(0, 10, 3);
 
-        assertTrue(buckets.equals(sameBuckets));
+        assertEquals(buckets, sameBuckets);
         assertEquals(buckets.hashCode(), sameBuckets.hashCode());
 
-        assertFalse(buckets.equals(null));
-        assertFalse(buckets.equals(9));
+        assertNotEquals(null, buckets);
+        assertNotEquals(9, buckets);
     }
 }

--- a/core/src/test/java/com/uber/m3/util/DurationTest.java
+++ b/core/src/test/java/com/uber/m3/util/DurationTest.java
@@ -23,8 +23,7 @@ package com.uber.m3.util;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
 
 public class DurationTest {
     private static final double EPSILON = 1e-10;
@@ -102,15 +101,15 @@ public class DurationTest {
 
     @Test
     public void equals() {
-        assertTrue(Duration.ZERO.equals(Duration.ZERO));
-        assertTrue(Duration.ZERO.equals(Duration.ofNanos(0)));
-        assertTrue(Duration.ofMillis(6000).equals(Duration.ofSeconds(6)));
-        assertTrue(Duration.ofHours(1).equals(Duration.ofNanos(3_600_000_000_000L)));
+        assertEquals(Duration.ZERO, Duration.ZERO);
+        assertEquals(Duration.ZERO, Duration.ofNanos(0));
+        assertEquals(Duration.ofMillis(6000), Duration.ofSeconds(6));
+        assertEquals(Duration.ofHours(1), Duration.ofNanos(3_600_000_000_000L));
         assertEquals(Duration.ofHours(1).hashCode(), Duration.ofNanos(3_600_000_000_000L).hashCode());
 
-        assertFalse(Duration.ofMillis(6001).equals(Duration.ofSeconds(6)));
-        assertFalse(Duration.ZERO.equals(null));
-        assertFalse(Duration.ZERO.equals(1));
+        assertNotEquals(Duration.ofMillis(6001), Duration.ofSeconds(6));
+        assertNotEquals(null, Duration.ZERO);
+        assertNotEquals(1, Duration.ZERO);
     }
 
     @Test

--- a/core/src/test/java/com/uber/m3/util/ImmutableListTest.java
+++ b/core/src/test/java/com/uber/m3/util/ImmutableListTest.java
@@ -25,11 +25,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ImmutableListTest {
     private ArrayList<String> helperList;
@@ -202,13 +198,13 @@ public class ImmutableListTest {
         helperList.add("zz");
         ImmutableList<String> differentList = new ImmutableList<>(helperList);
 
-        assertTrue(list.equals(sameList));
+        assertEquals(list, sameList);
         assertEquals(list.hashCode(), sameList.hashCode());
-        assertFalse(list.equals(differentList));
+        assertNotEquals(list, differentList);
         assertNotEquals(list.hashCode(), differentList.hashCode());
 
-        assertFalse(list.equals(null));
-        assertTrue(list.equals(list));
-        assertFalse(list.equals(1));
+        assertNotEquals(null, list);
+        assertEquals(list, list);
+        assertNotEquals(1, list);
     }
 }

--- a/core/src/test/java/com/uber/m3/util/ImmutableMapTest.java
+++ b/core/src/test/java/com/uber/m3/util/ImmutableMapTest.java
@@ -25,10 +25,7 @@ import org.junit.Test;
 
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ImmutableMapTest {
     private HashMap<String, String> helperMap;
@@ -73,11 +70,11 @@ public class ImmutableMapTest {
 
     @Test
     public void isEmpty() {
-        assertEquals(false, map.isEmpty());
+        assertFalse(map.isEmpty());
 
         map = new ImmutableMap<>(new HashMap<String, String>(0, 1));
 
-        assertEquals(true, map.isEmpty());
+        assertTrue(map.isEmpty());
     }
 
     @Test
@@ -102,7 +99,7 @@ public class ImmutableMapTest {
     public void get() {
         assertEquals("val1", map.get("key1"));
 
-        assertEquals(null, map.get("key9"));
+        assertNull(map.get("key9"));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -145,27 +142,27 @@ public class ImmutableMapTest {
         ImmutableMap<String, String> sameMap = new ImmutableMap.Builder<String, String>()
             .putAll(helperMap).build();
 
-        assertTrue(map.equals(sameMap));
+        assertEquals(map, sameMap);
     }
 
     @Test
     public void equals() {
-        assertFalse(map.equals(null));
-        assertFalse(map.equals(1));
-        assertTrue(map.equals(map));
+        assertNotEquals(null, map);
+        assertNotEquals(1, map);
+        assertEquals(map, map);
 
         ImmutableMap<String, String> sameMap = new ImmutableMap<>(helperMap);
 
-        assertTrue(map.equals(sameMap));
+        assertEquals(map, sameMap);
         assertEquals(map.hashCode(), sameMap.hashCode());
 
         helperMap.put("key7", "val7");
         ImmutableMap<String, String> differentMap = new ImmutableMap<>(helperMap);
 
-        assertFalse(map.equals(differentMap));
+        assertNotEquals(map, differentMap);
         assertNotEquals(map.hashCode(), differentMap.hashCode());
 
-        assertTrue(ImmutableMap.EMPTY.equals(new ImmutableMap(new HashMap())));
+        assertEquals(ImmutableMap.EMPTY, new ImmutableMap(new HashMap()));
     }
 
     @Test

--- a/core/src/test/java/com/uber/m3/util/ImmutableSetTest.java
+++ b/core/src/test/java/com/uber/m3/util/ImmutableSetTest.java
@@ -25,11 +25,7 @@ import org.junit.Test;
 
 import java.util.HashSet;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ImmutableSetTest {
     private HashSet<String> helperSet;
@@ -141,18 +137,18 @@ public class ImmutableSetTest {
     public void equals() {
         ImmutableSet<String> equalSet = new ImmutableSet<>(helperSet);
 
-        assertTrue(set.equals(equalSet));
+        assertEquals(set, equalSet);
         assertEquals(set.hashCode(), equalSet.hashCode());
 
         helperSet.add("zz");
         ImmutableSet<String> differentSet = new ImmutableSet<>(helperSet);
 
-        assertFalse(set.equals(differentSet));
+        assertNotEquals(set, differentSet);
         assertNotEquals(set.hashCode(), differentSet.hashCode());
 
-        assertFalse(set.equals(null));
-        assertTrue(set.equals(set));
-        assertFalse(set.equals(2));
+        assertNotEquals(null, set);
+        assertEquals(set, set);
+        assertNotEquals(2, set);
     }
 
     @Test


### PR DESCRIPTION
Several improvements are suggested in this PR:

- Introduced a new abstraction so that developers can manipulate time in tests.  The `MonotonicClock` interface offers an abstraction for us to manipulate time in test. It aims to improve the implementation of `TestScope` so that developers can verify metric recording of timers and histograms.

- Refactored how snapshots are created to leverage the same reporting mechanism used in regular metrics recording.

- Fixed snapshots for `Timers`, which seem to be broken at HEAD. The previous `TimerImpl` implementation relied on `NoReporterSink` to properly create `TimerSnapshot`s. However given `TestScope` instances are built with `NullStatsReporter`, `TimerSnapshots` were not being created at all when using `TestScope`.

- Leveraged the `ImmutableBuckets` implementation to compute bucket bounds in `HistogramImpl`, allowing removal of a substantial amount of duplicated code.

- Added unit tests to cover the fixes for `TimerSnapshots` as well as the changes to the snapshot logic.

The changes were structured in dependent but self-contained commits hoping to allow for easier code review. The lack of support for stacked PRs in Github made very difficult to create separate PRs for them.

The changes were tested according to instructions in `DEVELOPMENT.md`.