### PR TITLE
Downgrade PortUnreachableException in UDP flush from an exception to a warn log.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ configurations.archives.artifacts.clear()
 
 allprojects {
     group = 'com.uber.m3'
-    version = '0.14.2'
+    version = '0.14.3'
 
     apply plugin: 'java'
     apply plugin: 'maven'

--- a/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
+++ b/core/src/main/java/com/uber/m3/tally/ScopeImpl.java
@@ -25,7 +25,6 @@ import com.uber.m3.util.ImmutableMap;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledExecutorService;

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
@@ -25,6 +25,7 @@ import org.apache.thrift.transport.TTransportException;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
+import java.net.PortUnreachableException;
 import java.net.SocketAddress;
 import java.net.SocketException;
 

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
@@ -70,7 +70,7 @@ public class TUdpClient extends TUdpTransport implements AutoCloseable {
                     new DatagramPacket(writeBuffer.array(), writeBuffer.position())
                 );
             } catch (PortUnreachableException e) {
-                logger.error("UDP port unreachable during flush");
+                logger.warn("UDP port unreachable during flush");
             } catch (IOException e) {
                 throw new TTransportException(e);
             } finally {

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
@@ -68,6 +68,8 @@ public class TUdpClient extends TUdpTransport implements AutoCloseable {
                     //       directly
                     new DatagramPacket(writeBuffer.array(), writeBuffer.position())
                 );
+            } catch (PortUnreachableException e) {
+                logger.error("UDP port unreachable during flush", e);
             } catch (IOException e) {
                 throw new TTransportException(e);
             } finally {

--- a/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
+++ b/m3/src/main/java/com/uber/m3/tally/m3/thrift/TUdpClient.java
@@ -70,7 +70,7 @@ public class TUdpClient extends TUdpTransport implements AutoCloseable {
                     new DatagramPacket(writeBuffer.array(), writeBuffer.position())
                 );
             } catch (PortUnreachableException e) {
-                logger.error("UDP port unreachable during flush", e);
+                logger.error("UDP port unreachable during flush");
             } catch (IOException e) {
                 throw new TTransportException(e);
             } finally {


### PR DESCRIPTION
PortUnreachableException in the UDP flush is expected if the downstream metric collection service is not available. For the client library, it is not an not an issue that is actionable. At Uber our metrics collector can become overloaded and OOM or is otherwise temporarily unavailable during container upgrades, and PortUnreachableException causes a lot of noise and triggers alerts and deployment rollbacks for services.  Downgrading it from an exception to a warn log.